### PR TITLE
fix: now uses inputs node_version to determine the version of node

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -29,6 +29,15 @@ jobs:
       parent_directory: ${{ github.event.repository.name == '' && '.' || github.event.repository.name}}
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node_version }}
+    - id: npm-version
+      name: Show npm version
+      run: 'npm -v'
+    - id: node-version
+      name: Show node version
+      run: 'node -v'
     - name: Audit for vulnerabilities
       id: npm
       run: npx audit-ci@^7 --config ./audit-ci.json -o json > npm-security-check-reports.json

--- a/.github/workflows/security_npm_outdated.yml
+++ b/.github/workflows/security_npm_outdated.yml
@@ -36,8 +36,17 @@ jobs:
       parent_directory: ${{ github.event.repository.name == '' && '.' || github.event.repository.name}}
     steps:
     - uses: actions/checkout@v4
-    - id: install-npm
-      name: install-npm
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node_version }}
+    - id: npm-version
+      name: Show npm version
+      run: 'npm -v'
+    - id: node-version
+      name: Show node version
+      run: 'node -v'
+    - id: npm-ci
+      name: run npm ci 
       run: 'npm ci --no-audit'
     - name: Audit for vulnerabilities
       id: npm


### PR DESCRIPTION
As identified by Andy Lee - the built in version of node doesn't run properly against typescript projects.

This gives the benefit of running a specific version. Validated on my test project (and with the node -v and npm -v responses)