### PR TITLE
use the run_id rather than ref to prevent duplication failure

### DIFF
--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -91,7 +91,7 @@ jobs:
           -appname ${{ github.event.repository.name }} \
           -createprofile true \
           -deleteincompletescan 2 \
-          -version "${{ github.ref}}" \
+          -version "GITHUB-${{ github.run_id}}" \
           -filepath source.zip \
           2>&1 | tee output.txt 
 #      continue-on-error: true


### PR DESCRIPTION
Currently all but the first veracode policy scan will fail because the scan is being sent with the github ref (ref/main) which already exists on subsequent scans.

This fixes it by using the run_id