### PR TITLE
Add ECR repository for Trivy scans

### DIFF
--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -41,6 +41,9 @@ jobs:
         output: 'trivy-results.sarif'
         exit-code: 1
         limit-severities-for-sarif: true
+      env:
+        TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
+        TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1
       continue-on-error: true
     - name: Trivy upload sarif
       id: trivy-upload


### PR DESCRIPTION
with fallback to GHCR, should help mitigate rate-limiting issues