### PR TITLE
Heat 429 slack notification on deploy

### DIFF
--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.KUBE_TOKEN }}
         continue-on-error: true
 
-      - if: (${{ inputs.environment}} == 'prod' or ${{ inputs.environment }} == 'production') and ${{ vars.PROD_RELEASES_SLACK_CHANNEL }} != ''
+      - if: (${{ inputs.environment}} == 'prod' || ${{ inputs.environment }} == 'production') && ${{ vars.PROD_RELEASES_SLACK_CHANNEL }} != ''
         id: prod-slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
@@ -75,8 +75,10 @@ jobs:
                   }
                 ]
               }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
 
-      - if: (${{ inputs.environment}} != 'prod' and ${{ inputs.environment }} != 'production') and ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }} != ''
+      - if: (${{ inputs.environment}} != 'prod' && ${{ inputs.environment }} != 'production') && ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }} != ''
         id: nonprod-slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
@@ -110,3 +112,5 @@ jobs:
                   }
                 ]
               }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.KUBE_TOKEN }}
         continue-on-error: true
 
-      - if: ${{ inputs.environment == 'prod' || inputs.environment == 'production' }} && ${{ vars.PROD_RELEASES_SLACK_CHANNEL != '' }}
+      - if: ${{ ( inputs.environment == 'prod' || inputs.environment == 'production' ) && vars.PROD_RELEASES_SLACK_CHANNEL != '' }}
         id: prod-slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
@@ -78,7 +78,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
 
-      - if: ${{ inputs.environment != 'prod' && inputs.environment != 'production' }} && ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL != '' }}
+      - if: ${{ (inputs.environment != 'prod' && inputs.environment != 'production') &&  vars.NONPROD_RELEASES_SLACK_CHANNEL != '' }}
         id: nonprod-slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.KUBE_TOKEN }}
         continue-on-error: true
 
-      - if: (${{ inputs.environment}} == 'prod' || ${{ inputs.environment }} == 'production') && ${{ vars.PROD_RELEASES_SLACK_CHANNEL }} != ''
+      - if: ${{ inputs.environment == 'prod' || inputs.environment == 'production' }} && ${{ vars.PROD_RELEASES_SLACK_CHANNEL != '' }}
         id: prod-slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
@@ -78,7 +78,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
 
-      - if: (${{ inputs.environment}} != 'prod' && ${{ inputs.environment }} != 'production') && ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }} != ''
+      - if: ${{ inputs.environment != 'prod' && inputs.environment != 'production' }} && ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL != '' }}
         id: nonprod-slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -29,7 +29,7 @@ jobs:
         id: install
         with:
           version: latest
-      - uses:  ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v1 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v1 # WORKFLOW_VERSION
         id: deploy
         with:
           environment: ${{ inputs.environment }}
@@ -39,3 +39,74 @@ jobs:
           cluster: ${{ secrets.KUBE_CLUSTER }}
           namespace: ${{ secrets.KUBE_NAMESPACE }}
           token: ${{ secrets.KUBE_TOKEN }}
+        continue-on-error: true
+
+      - if: (${{ inputs.environment}} == 'prod' or ${{ inputs.environment }} == 'production') and ${{ vars.PROD_RELEASES_SLACK_CHANNEL }} != ''
+        id: prod-slack
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: ${{ vars.PROD_RELEASES_SLACK_CHANNEL }}
+          payload: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*${{ github.event.repository.name }}* version `${{ inputs.app_version }}` deploy to *${{ inputs.environment }}*"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Status:* ${{ steps.deploy.outcome }}"
+                      }
+                    ]
+                  }
+                ]
+              }
+
+      - if: (${{ inputs.environment}} != 'prod' and ${{ inputs.environment }} != 'production') and ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }} != ''
+        id: nonprod-slack
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}
+          payload: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*${{ github.event.repository.name }}* version `${{ inputs.app_version }}` deploy to *${{ inputs.environment }}*"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Status:* ${{ steps.deploy.outcome }}"
+                      }
+                    ]
+                  }
+                ]
+              }


### PR DESCRIPTION
This retrofits the slack notification on deployment. 
Requires two variables to be populated in the repo (these will be populated by the all-new bootstrap process):

NONPROD_RELEASE_SLACK_CHANNEL
PROD_RELEASE_SLACK_CHANNEL

no messages will be sent if these are blank