### PR TITLE
HEAT-455 - fix for trivy scans on a ghcr.io repository

### DIFF
--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Check repository in helm_deploy/values.yaml
       id: check-package-repo
       run: |
-        grep 'repository: ' helm_deploy/*/values.yaml | head -n1 | awk -F'[:/ ]+' '{print $3"/"$4}' >> $GITHUB_ENV
+        grep 'repository: ' helm_deploy/*/values.yaml | head -n1 | awk -F'[:/ ]+' '{print "repo="$3"/"$4}' >> $GITHUB_ENV
     - name: Trivy Image Vulnerability Scanner
       id: trivy-analyse
       uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0


### PR DESCRIPTION
This adds a step to the trivy scan to determine whether it's a quay.io package repository or a ghcr.io one.

Validated in dev.