### PR TITLE
Update name of the `security_trivy` job

### DIFF
--- a/templates/workflows/security_trivy.yml
+++ b/templates/workflows/security_trivy.yml
@@ -6,7 +6,7 @@ on:
     - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
 
 jobs:
-  security-kotlin-trivy-check:
+  security-trivy-check:
     name: Project security trivy dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v1 # WORKFLOW_VERSION
     with:


### PR DESCRIPTION
This job is common for both typescript and kotlin projects, and should be named appropriately