### PR TITLE
HEAT-422 commit history

### DIFF
--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -23,6 +23,19 @@ inputs:
   token:
     description: The KUBE_TOKEN
     required: true
+  k8s_deployment_name:
+    description: "Kubernetes deployment name"
+    default: 'PROJECT_NAME'
+    required: false
+  changelog_git_paths:
+    default: ""
+    description: When set it will limit the file changes shown in the changelog to the specified paths only. This is useful for multi-project builds where otherwise it will show all changes from all projects.
+    required: false
+
+outputs:
+  deployment_changelog:
+    description: "The changelog for the deployment" 
+    value: ${{ steps.get-deployment-changelog.outputs.DEPLOYMENT_CHANGELOG }}
 
 runs:
   using: composite
@@ -48,6 +61,17 @@ runs:
           *) environment=${{ inputs.environment }} ;;
         esac
         echo "environment=${environment}" | tee -a "$GITHUB_OUTPUT"
+
+    - name: get version history
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@HEAT-422_commit_history
+      if: ${{ inputs.show_changelog }}
+      id: version_history
+      with:
+        app_version: ${{ inputs.version }}
+        environment: ${{ inputs.environment }}
+        namespace: ${{ inputs.namespace }}
+        k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
+        changelog_git_paths: ${{ inputs.changelog_git_paths }}
 
     - name: Deploy
       shell: bash

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -38,7 +38,7 @@ inputs:
 outputs:
   deployment_changelog:
     description: "The changelog for the deployment" 
-    value: ${{ steps.get-deployment-changelog.outputs.DEPLOYMENT_CHANGELOG }}
+    value: ${{ steps.version_history.outputs.deployment_changelog }}
 
 runs:
   using: composite

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -31,6 +31,10 @@ inputs:
     default: ""
     description: When set it will limit the file changes shown in the changelog to the specified paths only. This is useful for multi-project builds where otherwise it will show all changes from all projects.
     required: false
+  show_changelog:
+    description: Whether the changelog should be sent by slack
+    default: "true"
+    required: false
 
 outputs:
   deployment_changelog:
@@ -64,7 +68,7 @@ runs:
 
     - name: get version history
       uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@HEAT-422_commit_history
-      if: ${{ inputs.show_changelog }}
+      if: ${{ inputs.show_changelog == 'true' }}
       id: version_history
       with:
         app_version: ${{ inputs.version }}

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -33,7 +33,6 @@ inputs:
     required: false
   show_changelog:
     description: Whether the changelog should be sent by slack
-    default: "true"
     required: false
 
 outputs:
@@ -68,7 +67,7 @@ runs:
 
     - name: get version history
       uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@HEAT-422_commit_history
-      if: ${{ inputs.show_changelog == 'true' }}
+      if: ${{ inputs.show_changelog }}
       id: version_history
       with:
         app_version: ${{ inputs.version }}

--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -24,6 +24,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: First line of slack commit only.
+    shell: bash
+    run: echo "commit_message_first_line=${{ github.event.head_commit.message }}" | head -n 1 >> $GITHUB_ENV
   - name: Slack - Send a message
     id: slack-release-message
     uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
@@ -52,7 +55,7 @@ runs:
                 "elements": [
                   {
                     "type": "mrkdwn",
-                    "text": ":github-${{ inputs.deploy_outcome }}: *Deploy status:* ${{ inputs.deploy_outcome }} - ${{ github.ref_name }} (${{ github.event.head_commit.message }})"
+                    "text": ":github-${{ inputs.deploy_outcome }}: *Deploy status:* ${{ inputs.deploy_outcome }} - ${{ github.ref_name }} (${{ env.commit_message_first_line }})"
                   },
                   {
                     "type": "plain_text",

--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -13,9 +13,14 @@ inputs:
   deploy_outcome:
     description: "The outcome of the deployment"
     required: true
+  deployment_changelog:
+    description: "A log of previous deployments"
+    required: false
+    default: ""
   slack_bot_token:
     description: "Slack bot token"
     required: true
+    
 runs:
   using: "composite"
   steps:
@@ -48,6 +53,10 @@ runs:
                   {
                     "type": "mrkdwn",
                     "text": ":github-${{ inputs.deploy_outcome }}: *Deploy status:* ${{ inputs.deploy_outcome }} - ${{ github.ref_name }} (${{ github.event.head_commit.message }})"
+                  },
+                  {
+                    "type": "plain_text",
+                    "text": "\n${{ inputs.deployment_changelog }}"
                   }
                 ]
               }

--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -27,6 +27,9 @@ runs:
   - name: First line of slack commit only.
     shell: bash
     run: echo "commit_message_first_line=${{ github.event.head_commit.message }}" | head -n 1 >> $GITHUB_ENV
+  - name: Debug the changelog
+    shell: bash
+    run: echo "deployment_changelog is as follows - ${{ inputs.deployment_changelog }}"
   - name: Slack - Send a message
     id: slack-release-message
     uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -1,4 +1,4 @@
-name: 'send a slack commit history message'
+name: 'get the commit history'
 description: 'Get the commits between the last deployment and the current one and send them to slack'
 inputs:
   app_version:
@@ -18,12 +18,6 @@ inputs:
     default: ""
     description: When set it will limit the file changes shown in the changelog to the specified paths only. This is useful for multi-project builds where otherwise it will show all changes from all projects.
     required: false
-  slack_channel_id:
-    description: "Slack channel to send to"
-    required: true
-  slack_bot_token:
-    description: "Slack bot token"
-    required: true 
 
 outputs:
   deployment_changelog:

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -81,7 +81,7 @@ runs:
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     
       echo "------------------------------------------"
       echo
-      echo "Here is the processed DEPLOYMENT_CHANGELOG"
+      echo "Here is the processed DEPLOYMENT_CHANGELOG - should not have double quotes or backticks"
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')'"
       echo "------------------------------------------"

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -83,7 +83,7 @@ runs:
       echo
       echo "Here is the processed DEPLOYMENT_CHANGELOG - should not have double quotes or backticks"
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')'"
+      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')'" >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')" >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -75,6 +75,10 @@ runs:
       else
         echo "Changelog not available." > .deployment_changelog
       fi
-
+      
+      echo "Here is the processed DEPLOYMENT_CHANGELOG"
+      echo "------------------------------------------"
+      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"\"
+      echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"\" >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -69,12 +69,12 @@ runs:
         PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed -e 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' -e ':a;N;$!ba;s/\n/\\n/g' \
+          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
           | tr '"' "'" | tr "\`" "'" \
           >> .deployment_changelog
       else
         echo "Changelog not available." > .deployment_changelog
       fi
 
-      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog)\"" >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog)\" | -e ':a;N;$!ba;s/\n/\\n/g' " >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -45,11 +45,14 @@ runs:
       fi
 
       # initialise the changelog
+      echo "Touching .deployment_changelog"
       touch .deployment_changelog
 
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }} " | cut -d'.' -f3)"
       K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
-      
+      echo "CURRENT_COMMIT=${CURRENT_COMMIT}"
+      echo "K8S_PREVIOUS_APP_VERSION=${K8S_PREVIOUS_APP_VERSION}"      
+
       if [[ "$K8S_PREVIOUS_APP_VERSION" == "" ]]; then
       # if no previous version was found, set to current commit minus 1
         echo "Previous deployment not found, showing current commit only." >> .deployment_changelog
@@ -57,15 +60,15 @@ runs:
       else
         PREVIOUS_COMMIT="$(echo "${K8S_PREVIOUS_APP_VERSION}" | cut -d'.' -f3)"
       fi
-
+      echo "PREVIOUS_COMMIT=${PREVIOUS_COMMIT}"
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
-      # Check $previous_commit sha1 is valid
-      git rev-parse --quiet --verify "${previous_commit}"
-      if git rev-parse --quiet --verify "${previous_commit}" &>/dev/null; then
+      # Check $PREVIOUS_COMMIT sha1 is valid
+      git rev-parse --quiet --verify "${PREVIOUS_COMMIT}"
+      if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # shellcheck disable=SC2086
         PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
-          "${previous_commit}..${current_commit}" $CHANGELOG_GIT_PATHS \
+          "$PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
           | tr '"' "'" | tr "\`" "'" \
           >> .deployment_changelog

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -34,10 +34,8 @@ runs:
       | 
       echo "K8S_DEPLOYMENT_NAME=${{ inputs.k8s_deployment_name }}"
       echo "Cluster: ${{ inputs.namespace }}"
-      echo "Slack channel: ${{ inputs.slack_channel_id }}"
       echo "App version: ${{ inputs.app_version }}"
       echo "Changelog git paths: ${{ inputs.changelog_git_paths }}"
-      echo "Show changelog: ${{ inputs.show_changelog }}"
       echo "--------------------------------------------"
       echo "Processing the commit history..."
       if [[ "${{ inputs.k8s_deployment_name }}" == "PROJECT_NAME" ]]; then
@@ -62,6 +60,7 @@ runs:
 
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
       # Check $previous_commit sha1 is valid
+      git rev-parse --quiet --verify "${previous_commit}"
       if git rev-parse --quiet --verify "${previous_commit}" &>/dev/null; then
         # shellcheck disable=SC2086
         PAGER="cat" git log --oneline --no-decorate \

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -69,7 +69,7 @@ runs:
         PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
+          | sed -e 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' -e ':a;N;$!ba;s/\n/\\n/g' \
           | tr '"' "'" | tr "\`" "'" \
           >> .deployment_changelog
       else

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -62,6 +62,10 @@ runs:
       fi
       echo "PREVIOUS_COMMIT=${PREVIOUS_COMMIT}"
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
+
+      # Debug - run a basic git log to see if it works    
+      git log | head -n 10
+
       # Check $PREVIOUS_COMMIT sha1 is valid
       git rev-parse --quiet --verify "${PREVIOUS_COMMIT}"
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -48,9 +48,9 @@ runs:
       echo "Touching .deployment_changelog"
       touch .deployment_changelog
 
-      CURRENT_COMMIT="$(echo "${{ inputs.app_version }} " | cut -d'.' -f3)"
+      CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
       K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
-      echo "CURRENT_COMMIT=${CURRENT_COMMIT}"
+      echo "CURRENT_COMMIT=[${CURRENT_COMMIT}]"
       echo "K8S_PREVIOUS_APP_VERSION=${K8S_PREVIOUS_APP_VERSION}"      
 
       if [[ "$K8S_PREVIOUS_APP_VERSION" == "" ]]; then

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -50,7 +50,7 @@ runs:
 
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
       K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
-      echo "CURRENT_COMMIT=[${CURRENT_COMMIT}]"
+      echo "CURRENT_COMMIT=${CURRENT_COMMIT}"
       echo "K8S_PREVIOUS_APP_VERSION=${K8S_PREVIOUS_APP_VERSION}"      
 
       if [[ "$K8S_PREVIOUS_APP_VERSION" == "" ]]; then
@@ -75,10 +75,15 @@ runs:
       else
         echo "Changelog not available." > .deployment_changelog
       fi
-      
+
+      echo "Here is the unprocessed DEPLOYMENT_CHANGELOG"
+      echo "------------------------------------------"
+      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     
+      echo "------------------------------------------"
+      echo
       echo "Here is the processed DEPLOYMENT_CHANGELOG"
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"\"
+      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')'"
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"\" >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')' >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -64,10 +64,6 @@ runs:
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
 
       # Check $PREVIOUS_COMMIT sha1 is valid
-      echo "Running git rev-parse --quiet --verify ${PREVIOUS_COMMIT}"
-      git rev-parse --quiet --verify "${PREVIOUS_COMMIT}"
-      echo "Just ran git rev-parse --quiet --verify ${PREVIOUS_COMMIT}"
-
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # shellcheck disable=SC2086
         PAGER="cat" git log --oneline --no-decorate \

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -64,6 +64,7 @@ runs:
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
 
       # Check $PREVIOUS_COMMIT sha1 is valid
+      echo "Running git rev-parse --quiet --verify ${PREVIOUS_COMMIT}"
       git rev-parse --quiet --verify "${PREVIOUS_COMMIT}"
       echo "Just ran git rev-parse --quiet --verify ${PREVIOUS_COMMIT}"
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -76,5 +76,5 @@ runs:
         echo "Changelog not available." > .deployment_changelog
       fi
 
-      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog)\" | -e ':a;N;$!ba;s/\n/\\n/g' " >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog\" | sed ':a;N;$!ba;s/\n/\\n/g')" >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -63,16 +63,15 @@ runs:
       echo "PREVIOUS_COMMIT=${PREVIOUS_COMMIT}"
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
 
-      # Debug - run a basic git log to see if it works    
-      git log | head -n 10
-
       # Check $PREVIOUS_COMMIT sha1 is valid
       git rev-parse --quiet --verify "${PREVIOUS_COMMIT}"
+      echo "Just ran git rev-parse --quiet --verify ${PREVIOUS_COMMIT}"
+
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # shellcheck disable=SC2086
         PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
-          "$PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
+          "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
           | tr '"' "'" | tr "\`" "'" \
           >> .deployment_changelog

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -1,0 +1,84 @@
+name: 'send a slack commit history message'
+description: 'Get the commits between the last deployment and the current one and send them to slack'
+inputs:
+  app_version:
+    description: "version of the app being deployed"
+    required: true
+  environment:
+    description: "deployment environment"
+    required: true
+  namespace:
+    description: "Kubernetes namespace"
+    required: true
+  k8s_deployment_name:
+    description: "Kubernetes deployment name"
+    default: 'PROJECT_NAME'
+    required: false
+  changelog_git_paths:
+    default: ""
+    description: When set it will limit the file changes shown in the changelog to the specified paths only. This is useful for multi-project builds where otherwise it will show all changes from all projects.
+    required: false
+  slack_channel_id:
+    description: "Slack channel to send to"
+    required: true
+  slack_bot_token:
+    description: "Slack bot token"
+    required: true 
+
+outputs:
+  deployment_changelog:
+    description: "The changelog for the deployment" 
+    value: ${{ steps.get-deployment-changelog.outputs.DEPLOYMENT_CHANGELOG }}
+
+runs:
+  using: "composite"
+  steps:
+  - name: find the latest deployment_name
+    id: get-deployment-changelog
+    shell: bash
+    run:
+      | 
+      echo "K8S_DEPLOYMENT_NAME=${{ inputs.k8s_deployment_name }}"
+      echo "Cluster: ${{ inputs.namespace }}"
+      echo "Slack channel: ${{ inputs.slack_channel_id }}"
+      echo "App version: ${{ inputs.app_version }}"
+      echo "Changelog git paths: ${{ inputs.changelog_git_paths }}"
+      echo "Show changelog: ${{ inputs.show_changelog }}"
+      echo "--------------------------------------------"
+      echo "Processing the commit history..."
+      if [[ "${{ inputs.k8s_deployment_name }}" == "PROJECT_NAME" ]]; then
+        K8S_DEPLOYMENT_NAME="${{ github.event.repository.name }}"
+      else
+        K8S_DEPLOYMENT_NAME="${{ inputs.k8s_deployment_name }}"
+      fi
+
+      # initialise the changelog
+      touch .deployment_changelog
+
+      CURRENT_COMMIT="$(echo "${{ inputs.app_version }} " | cut -d'.' -f3)"
+      K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
+      
+      if [[ "$K8S_PREVIOUS_APP_VERSION" == "" ]]; then
+      # if no previous version was found, set to current commit minus 1
+        echo "Previous deployment not found, showing current commit only." >> .deployment_changelog
+        PREVIOUS_COMMIT="${CURRENT_COMMIT}^1"
+      else
+        PREVIOUS_COMMIT="$(echo "${K8S_PREVIOUS_APP_VERSION}" | cut -d'.' -f3)"
+      fi
+
+      # Some apps may not have set the correct k8s label with a valid app version containing a sha1
+      # Check $previous_commit sha1 is valid
+      if git rev-parse --quiet --verify "${previous_commit}" &>/dev/null; then
+        # shellcheck disable=SC2086
+        PAGER="cat" git log --oneline --no-decorate \
+          --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
+          "${previous_commit}..${current_commit}" $CHANGELOG_GIT_PATHS \
+          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
+          | tr '"' "'" | tr "\`" "'" \
+          >> .deployment_changelog
+      else
+        echo "Changelog not available." > .deployment_changelog
+      fi
+
+      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog)\"" >> $GITHUB_OUTPUT
+

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -85,5 +85,5 @@ runs:
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')'"
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')' >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')'" >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -76,5 +76,5 @@ runs:
         echo "Changelog not available." > .deployment_changelog
       fi
 
-      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog\" | sed ':a;N;$!ba;s/\n/\\n/g')" >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=\"$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"\" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -40,6 +40,8 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: azure/setup-kubectl@v4
         id: install
         with:

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -51,7 +51,7 @@ jobs:
           if [[ "${{ inputs.environment }}" == "prod" ]]; then
             echo "slack_channel_id=${{ vars.PROD_RELEASES_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
           else
-            echo "slack_channel_id=${{ vars.NON_PROD_RELEASE_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
+            echo "slack_channel_id=${{ vars.NON_PROD_RELEASES_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
           fi
 
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@HEAT-422_commit_history

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -44,7 +44,12 @@ jobs:
         id: install
         with:
           version: latest
-      
+
+      - name: Install Git
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git
+     
       - name: Set Slack Channel ID
         id: set-slack-channel-id
         run: |

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -11,6 +11,21 @@ on:
         description: App version
         required: true 
         type: string
+      k8s_deployment_name:
+        description: Kubernetes deployment name
+        default: "PROJECT_NAME"
+        required: false
+        type: string
+      changelog_git_paths:
+        description: Changelog git paths
+        required: false
+        default: ""
+        type: string
+      show_changelog:
+        description: Show changelog
+        default: true
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -29,6 +44,28 @@ jobs:
         id: install
         with:
           version: latest
+      
+      - name: Set Slack Channel ID
+        id: set-slack-channel-id
+        run: |
+          if [[ "${{ inputs.environment }}" == "prod" ]]; then
+            echo "slack_channel_id=${{ vars.PROD_RELEASES_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
+          else
+            echo "slack_channel_id=${{ vars.NON_PROD_RELEASE_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@HEAT-422_commit_history
+        if: ${{ inputs.show_changelog }}
+        id: version_history
+        with:
+          app_version: ${{ inputs.app_version }}
+          environment: ${{ inputs.environment }}
+          namespace: ${{ secrets.KUBE_NAMESPACE }}
+          k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
+          changelog_git_paths: ${{ inputs.changelog_git_paths }}
+          slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ steps.set-slack-channel-id.outputs.slack_channel_id || 'CVA3MKDTR '}} 
+
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
         id: deploy
         with:
@@ -44,33 +81,24 @@ jobs:
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR
       - if: ${{  inputs.environment == 'prod' || inputs.environment == 'production' }} 
         id: prod-dps-slack
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_release_results@v2 # WORKFLOW_VERSION
+        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_release_results@HEAT-422_commit_history # WORKFLOW_VERSION
         with:
           channel_id: 'CVA3MKDTR'
           environment: ${{ inputs.environment }}
           app_version: ${{ inputs.app_version }}
           deploy_outcome: ${{ steps.deploy.outcome }}
           slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
+          deployment_changelog: ${{ steps.version_history.outputs.deployment_changelog }}
 
       
       # Optional prod releases slack channel (using PROD_RELEASES_SLACK_CHANNEL variable)
-      - if: ${{ ( inputs.environment == 'prod' || inputs.environment == 'production' ) && vars.PROD_RELEASES_SLACK_CHANNEL != '' }}
-        id: prod-slack
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_release_results@v2 # WORKFLOW_VERSION
+      - if: ${{ steps.set-slack-channel-id.outputs.slack_channel_id != '' }}
+        id: send-release-slack
+        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_release_results@HEAT-422_commit_history # WORKFLOW_VERSION
         with:
-          channel_id: ${{ vars.PROD_RELEASES_SLACK_CHANNEL }}
+          channel_id: ${{ steps.set-slack-channel-id.outputs.slack_channel_id }}
           environment: ${{ inputs.environment }}
           app_version: ${{ inputs.app_version }}
           deploy_outcome: ${{ steps.deploy.outcome }}
           slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
-
-      # Optional non-prod releases slack channel (using NONPROD_RELEASES_SLACK_CHANNEL variable)
-      - if: ${{ (inputs.environment != 'prod' && inputs.environment != 'production') &&  vars.NONPROD_RELEASES_SLACK_CHANNEL != '' }}
-        id: nonprod-slack
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_release_results@v2 # WORKFLOW_VERSION
-        with:
-          channel_id: ${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}
-          environment: ${{ inputs.environment }}
-          app_version: ${{ inputs.app_version }}
-          deploy_outcome: ${{ steps.deploy.outcome }}
-          slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
+          deployment_changelog: ${{ steps.version_history.outputs.deployment_changelog }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -49,9 +49,9 @@ jobs:
         id: set-slack-channel-id
         run: |
           if [[ "${{ inputs.environment }}" == "prod" ]]; then
-            echo "slack_channel_id=${{ vars.PROD_RELEASES_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
+            echo "slack_channel_id=${{ vars.PROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           else
-            echo "slack_channel_id=${{ vars.NON_PROD_RELEASES_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
+            echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           fi
 
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@HEAT-422_commit_history # WORKFLOW_VERSION

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -44,11 +44,6 @@ jobs:
         id: install
         with:
           version: latest
-
-      - name: Install Git
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git
      
       - name: Set Slack Channel ID
         id: set-slack-channel-id

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -63,8 +63,6 @@ jobs:
           namespace: ${{ secrets.KUBE_NAMESPACE }}
           k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
           changelog_git_paths: ${{ inputs.changelog_git_paths }}
-          slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
-          slack_channel_id: ${{ steps.set-slack-channel-id.outputs.slack_channel_id || 'CVA3MKDTR '}} 
 
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
         id: deploy
@@ -76,6 +74,8 @@ jobs:
           cluster: ${{ secrets.KUBE_CLUSTER }}
           namespace: ${{ secrets.KUBE_NAMESPACE }}
           token: ${{ secrets.KUBE_TOKEN }}
+          k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
+          changelog_git_paths: ${{ inputs.changelog_git_paths }}
         continue-on-error: true
 
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -94,4 +94,4 @@ jobs:
           app_version: ${{ inputs.app_version }}
           deploy_outcome: ${{ steps.deploy.outcome }}
           slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
-          deployment_changelog: ${{ steps.version_history.outputs.deployment_changelog }}
+          deployment_changelog: ${{ steps.deploy.outputs.deployment_changelog }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -66,6 +66,7 @@ jobs:
           token: ${{ secrets.KUBE_TOKEN }}
           k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
           changelog_git_paths: ${{ inputs.changelog_git_paths }}
+          show_changelog: ${{ inputs.show_changelog }}
         continue-on-error: true
 
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR
@@ -78,7 +79,7 @@ jobs:
           app_version: ${{ inputs.app_version }}
           deploy_outcome: ${{ steps.deploy.outcome }}
           slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
-          deployment_changelog: ${{ steps.version_history.outputs.deployment_changelog }}
+          deployment_changelog: ${{ steps.deploy.outputs.deployment_changelog }}
 
       
       # Optional prod releases slack channel (using PROD_RELEASES_SLACK_CHANNEL variable)

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -54,17 +54,7 @@ jobs:
             echo "slack_channel_id=${{ vars.NON_PROD_RELEASES_SLACK_CHANNEL }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@HEAT-422_commit_history
-        if: ${{ inputs.show_changelog }}
-        id: version_history
-        with:
-          app_version: ${{ inputs.app_version }}
-          environment: ${{ inputs.environment }}
-          namespace: ${{ secrets.KUBE_NAMESPACE }}
-          k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
-          changelog_git_paths: ${{ inputs.changelog_git_paths }}
-
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@HEAT-422_commit_history # WORKFLOW_VERSION
         id: deploy
         with:
           environment: ${{ inputs.environment }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "labels": ["dependencies", "github-actions"]
+}


### PR DESCRIPTION
Improves the slack message to include commit history in the same way as the existing CircleCI process runs.

This also includes the first line of the commit message to prevent failure of slack messages if it's a multiline message (HEAT-467)

This also covers HEAT-431 