### PR TITLE
HEAT-491: IP allowlists - add provision for IP allowlist using org variables

### DIFF
--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -98,9 +98,6 @@ runs:
       shell: bash
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        if -n "${{ inputs.helm_allowlist_groups }}"; then
-
-        fi
         brew install helm
         yq -i ".appVersion = \"${{ inputs.version }}\"" "${{ inputs.helm_dir }}/${{ github.event.repository.name }}/Chart.yaml"
         helm dependency update "${{ inputs.helm_dir }}/${{ github.event.repository.name }}"
@@ -115,6 +112,6 @@ runs:
           --timeout ${{ inputs.helm_timeout }} \
           --values 'helm_deploy/values-${{ steps.env.outputs.environment }}.yaml' \
           ${{ inputs.helm_additional_args }} \
-          ${{ inputs.helm_allowlist_groups}} \
+          ${{ inputs.helm_allowlist_groups }} \
           ${{ inputs.helm_allowlist_version }} \
           --wait

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -94,6 +94,23 @@ runs:
         k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
         changelog_git_paths: ${{ inputs.changelog_git_paths }}
 
+    - name: Check for IP_ALLOWLIST_GROUPS_YAML
+      shell: bash
+      id: check-ip-allowlists
+      run: |
+        if [[ -n "${{ inputs.helm_allowlist_groups }}" ]]; then
+          echo "${{ inputs.helm_allowlist_groups }}" | base64 --decode > ./ip-allowlist-groups.yaml
+          echo "ALLOWLIST_GROUPS=--values ./ip-allowlist-groups.yaml" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check for IP_ALLOWLIST_GROUPS_VERSION
+      shell: bash
+      id: check-ip-allowlists-version
+      run: |
+        if [[ -n "${{ inputs.helm_allowlist_version }}" ]]; then
+          echo "ALLOWLIST_VERSION=--set generic-service.allowlist_version=${{ inputs.helm_allowlist_version }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Deploy
       shell: bash
       run: |
@@ -112,6 +129,6 @@ runs:
           --timeout ${{ inputs.helm_timeout }} \
           --values 'helm_deploy/values-${{ steps.env.outputs.environment }}.yaml' \
           ${{ inputs.helm_additional_args }} \
-          ${{ inputs.helm_allowlist_groups }} \
-          ${{ inputs.helm_allowlist_version }} \
+          ${{ steps.check-ip-allowlists.outputs.ALLOWLIST_GROUPS }} \
+          ${{ steps.check-ip-allowlists-version.outputs.ALLOWLIST_VERSION }} \
           --wait

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -45,7 +45,13 @@ inputs:
   helm_dir: 
     description: location of helm configuration
     required: false
-    default: helm_deploy 
+    default: helm_deploy
+  helm_allowlist_groups:
+    description: values for location of allowlist groups file
+    required: false
+  helm_allowlist_version:
+    description: setting for version of allowlist file
+    required: false
 
 outputs:
   deployment_changelog:
@@ -92,6 +98,9 @@ runs:
       shell: bash
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        if -n "${{ inputs.helm_allowlist_groups }}"; then
+
+        fi
         brew install helm
         yq -i ".appVersion = \"${{ inputs.version }}\"" "${{ inputs.helm_dir }}/${{ github.event.repository.name }}/Chart.yaml"
         helm dependency update "${{ inputs.helm_dir }}/${{ github.event.repository.name }}"
@@ -106,4 +115,6 @@ runs:
           --timeout ${{ inputs.helm_timeout }} \
           --values 'helm_deploy/values-${{ steps.env.outputs.environment }}.yaml' \
           ${{ inputs.helm_additional_args }} \
+          ${{ inputs.helm_allowlist_groups}} \
+          ${{ inputs.helm_allowlist_version }} \
           --wait

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -80,8 +80,8 @@ jobs:
         id: check-ip-allowlists
         run: |
           if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
-            echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ./ip-allowlist-groups.yaml
-            echo "ALLOWLIST_GROUPS=--values ./ip-allowlist-groups.yaml" >> $GITHUB_OUTPUT
+            echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ip-allowlist-groups.yaml
+            echo "ALLOWLIST_GROUPS=--values ip-allowlist-groups.yaml" >> $GITHUB_OUTPUT
           fi
 
       - name: Check for IP_ALLOWLIST_GROUPS_VERSION

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -76,7 +76,7 @@ jobs:
             echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           fi
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@HEAT-491-ip-allowlists # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
         id: deploy
         with:
           environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -79,22 +79,20 @@ jobs:
       - name: Check for IP_ALLOWLIST_GROUPS_YAML
         id: check-ip-allowlists
         run: |
-          if [[ -n "${{ vars.IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
-            echo "TODO: add the allowlist to the helm variables"
-            echo "${IP_ALLOWLIST_GROUPS_YAML}" | base64 --decode > ip-allowlist-groups.yaml
-            HELM_ARGS+=("--values" "ip-allowlist-groups.yaml")
+          if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
+            echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ip-allowlist-groups.yaml
+            echo "ALLOWLIST_GROUPS=--values ./ip-allowlist-groups.yaml") >> $GITHUB_OUTPUT
           fi
 
       - name: Check for IP_ALLOWLIST_GROUPS_VERSION
         id: check-ip-allowlists-version
         run: |
-          if [[ -n "${{ vars.IP_ALLOWLIST_GROUPS_VERSION }}" ]]; then
-            echo "TODO: add the allowlist version to the helm variables"
-            # HELM_ARGS+=("--set" "generic-service.allowlist_version=${IP_ALLOWLIST_GROUPS_VERSION}")
+          if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}" ]]; then
+            echo "ALLOWLIST_VERSION=--set generic-service.allowlist_version=${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}" >> $GITHUB_OUTPUT
           fi
           
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@HEAT-491-ip-allowlists # WORKFLOW_VERSION
         id: deploy
         with:
           environment: ${{ inputs.environment }}
@@ -110,6 +108,8 @@ jobs:
           helm_additional_args: ${{ inputs.helm_additional_args }}
           helm_timeout: ${{ inputs.helm_timeout }}
           helm_dir: ${{ inputs.helm_dir }}
+          helm_allowlist_groups: ${{ steps.check-ip-allowlists.outputs.ALLOWLIST_GROUPS }}
+          helm_allowlist_groups_version: ${{ steps.check-ip-allowlists-version.outputs.ALLOWLIST_VERSION }}
 
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR
       - if: ${{ always() && ( inputs.environment == 'prod' || inputs.environment == 'production' ) }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -76,21 +76,6 @@ jobs:
             echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           fi
 
-      - name: Check for IP_ALLOWLIST_GROUPS_YAML
-        id: check-ip-allowlists
-        run: |
-          if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
-            echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ip-allowlist-groups.yaml
-            echo "ALLOWLIST_GROUPS=--values ip-allowlist-groups.yaml" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check for IP_ALLOWLIST_GROUPS_VERSION
-        id: check-ip-allowlists-version
-        run: |
-          if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}" ]]; then
-            echo "ALLOWLIST_VERSION=--set generic-service.allowlist_version=${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}" >> $GITHUB_OUTPUT
-          fi
-
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@HEAT-491-ip-allowlists # WORKFLOW_VERSION
         id: deploy
         with:
@@ -107,8 +92,8 @@ jobs:
           helm_additional_args: ${{ inputs.helm_additional_args }}
           helm_timeout: ${{ inputs.helm_timeout }}
           helm_dir: ${{ inputs.helm_dir }}
-          helm_allowlist_groups: ${{ steps.check-ip-allowlists.outputs.ALLOWLIST_GROUPS }}
-          helm_allowlist_version: ${{ steps.check-ip-allowlists-version.outputs.ALLOWLIST_VERSION }}
+          helm_allowlist_groups: ${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}
+          helm_allowlist_version: ${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}
 
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR
       - if: ${{ always() && ( inputs.environment == 'prod' || inputs.environment == 'production' ) }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
             echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ip-allowlist-groups.yaml
-            echo "ALLOWLIST_GROUPS=--values ./ip-allowlist-groups.yaml") >> $GITHUB_OUTPUT
+            echo "ALLOWLIST_GROUPS=--values ./ip-allowlist-groups.yaml" >> $GITHUB_OUTPUT
           fi
 
       - name: Check for IP_ALLOWLIST_GROUPS_VERSION

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -76,6 +76,24 @@ jobs:
             echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           fi
 
+      - name: Check for IP_ALLOWLIST_GROUPS_YAML
+        id: check-ip-allowlists
+        run: |
+          if [[ -n "${{ vars.IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
+            echo "TODO: add the allowlist to the helm variables"
+            echo "${IP_ALLOWLIST_GROUPS_YAML}" | base64 --decode > ip-allowlist-groups.yaml
+            HELM_ARGS+=("--values" "ip-allowlist-groups.yaml")
+          fi
+
+      - name: Check for IP_ALLOWLIST_GROUPS_VERSION
+        id: check-ip-allowlists-version
+        run: |
+          if [[ -n "${{ vars.IP_ALLOWLIST_GROUPS_VERSION }}" ]]; then
+            echo "TODO: add the allowlist version to the helm variables"
+            # HELM_ARGS+=("--set" "generic-service.allowlist_version=${IP_ALLOWLIST_GROUPS_VERSION}")
+          fi
+          
+
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
         id: deploy
         with:

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -80,7 +80,7 @@ jobs:
         id: check-ip-allowlists
         run: |
           if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" ]]; then
-            echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ip-allowlist-groups.yaml
+            echo "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}" | base64 --decode > ./ip-allowlist-groups.yaml
             echo "ALLOWLIST_GROUPS=--values ./ip-allowlist-groups.yaml" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -90,7 +90,6 @@ jobs:
           if [[ -n "${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}" ]]; then
             echo "ALLOWLIST_VERSION=--set generic-service.allowlist_version=${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}" >> $GITHUB_OUTPUT
           fi
-          
 
       - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@HEAT-491-ip-allowlists # WORKFLOW_VERSION
         id: deploy
@@ -109,7 +108,7 @@ jobs:
           helm_timeout: ${{ inputs.helm_timeout }}
           helm_dir: ${{ inputs.helm_dir }}
           helm_allowlist_groups: ${{ steps.check-ip-allowlists.outputs.ALLOWLIST_GROUPS }}
-          helm_allowlist_groups_version: ${{ steps.check-ip-allowlists-version.outputs.ALLOWLIST_VERSION }}
+          helm_allowlist_version: ${{ steps.check-ip-allowlists-version.outputs.ALLOWLIST_VERSION }}
 
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR
       - if: ${{ always() && ( inputs.environment == 'prod' || inputs.environment == 'production' ) }}


### PR DESCRIPTION
Matt's done the hard work of deploying the values to org variable - this includes the two variables in the `./ip-allowlist-groups.yaml` file (in the case of the allowlist) and the `generic-service.allowlist_version` variable.

I've managed to deploy to james-kotlin-test with the parameters, but still looking to validate.