### PR TITLE
node-version-file syntax correction on security scans

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node_version_file: ${{ inputs.node_version_file }}
+        node-version-file: ${{ inputs.node_version_file }}
     - name: Show npm version
       id: npm-version
       run: 'npm -v'

--- a/.github/workflows/security_npm_outdated.yml
+++ b/.github/workflows/security_npm_outdated.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version_file: ${{ inputs.node_version_file }}
+          node-version-file: ${{ inputs.node_version_file }}
       - id: npm-version
         name: Show npm version
         run: "npm -v"


### PR DESCRIPTION
There were some typos in the `with` clause of `setup-node` - this corrects them.