### PR TITLE
Add  optional `tag_latest` input  to `build_docker` action

### DIFF
--- a/.github/actions/build-test-and-deploy/build_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_docker/action.yml
@@ -23,6 +23,10 @@ inputs:
   app_version: 
     description: App version
     required: true
+  tag_latest:
+    description: Tag image as 'latest'
+    required: false
+    default: true
   HMPPS_QUAYIO_USER:
     description: Docker registry username 
     required: false
@@ -78,7 +82,6 @@ runs:
           "GIT_BRANCH=${{ github.ref_name }}"
           "${{ inputs.additional_docker_build_args }}"
         tags: |
-          ${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest
+          ${{ if inputs.tag_latest == 'true' }}${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest
           ${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}
-
 


### PR DESCRIPTION
- Add optional `tag_latest` input to the `build_docker` action to allow building and publishing an image, without making it `latest`
- Defaults to `true` to not break any existing use. Overriding value with `false` will stop the image getting the latest tag