### PR TITLE
Add optional tag_latest input to build_docker action (Attempt #2)

### DIFF
--- a/.github/actions/build-test-and-deploy/build_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_docker/action.yml
@@ -68,7 +68,17 @@ runs:
       #   if: ${{ inputs.docker_registry  == 'ecr' }}
       #   uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build Docker images 
+    - name: Set Docker Tags
+      id: set_tags
+      shell: bash
+      run: |
+        TAGS="${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}"
+        if [[ "${{ inputs.tag_latest }}" == "true" ]]; then
+          TAGS="${TAGS},${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest"
+        fi
+        echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+    - name: Build Docker Image
       uses: docker/build-push-action@v6
       with:
         cache-from: type=gha
@@ -81,7 +91,4 @@ runs:
           "GIT_REF=${{ github.sha }}"
           "GIT_BRANCH=${{ github.ref_name }}"
           "${{ inputs.additional_docker_build_args }}"
-        tags: |
-          ${{ if inputs.tag_latest == 'true' }}${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest
-          ${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}
-
+        tags: ${{ steps.set_tags.outputs.tags }}

--- a/.github/actions/build-test-and-deploy/build_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_docker/action.yml
@@ -73,9 +73,15 @@ runs:
       shell: bash
       run: |
         TAGS="${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}"
+        
         if [[ "${{ inputs.tag_latest }}" == "true" ]]; then
           TAGS="${TAGS},${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest"
         fi
+        
+        if [[ -n "${{ inputs.additional_docker_tag }}" ]]; then
+          TAGS="${TAGS},${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.additional_docker_tag }}"
+        fi
+        
         echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
     - name: Build Docker Image

--- a/.github/actions/build-test-and-deploy/build_multiplatform_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_multiplatform_docker/action.yml
@@ -74,9 +74,15 @@ runs:
       shell: bash
       run: |
         TAGS="${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}"
+        
         if [[ "${{ inputs.tag_latest }}" == "true" ]]; then
           TAGS="${TAGS},${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest"
         fi
+        
+        if [[ -n "${{ inputs.additional_docker_tag }}" ]]; then
+          TAGS="${TAGS},${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.additional_docker_tag }}"
+        fi
+        
         echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
     - name: Build Docker images 

--- a/.github/actions/build-test-and-deploy/build_multiplatform_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_multiplatform_docker/action.yml
@@ -23,6 +23,10 @@ inputs:
   app_version: 
     description: App version
     required: true
+  tag_latest:
+    description: Tag image as 'latest'
+    required: false
+    default: true
   HMPPS_QUAYIO_USER:
     description: Docker registry username 
     required: false
@@ -64,7 +68,17 @@ runs:
       # - name: Login to Amazon ECR
       #   if: ${{ inputs.docker_registry  == 'ecr' }}
       #   uses: aws-actions/amazon-ecr-login@v1
-      
+
+    - name: Set Docker Tags
+      id: set_tags
+      shell: bash
+      run: |
+        TAGS="${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}"
+        if [[ "${{ inputs.tag_latest }}" == "true" ]]; then
+          TAGS="${TAGS},${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest"
+        fi
+        echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
     - name: Build Docker images 
       uses: docker/build-push-action@v6
       with:
@@ -79,6 +93,4 @@ runs:
           "GIT_REF=${{ github.sha }}"
           "GIT_BRANCH=${{ github.ref_name }}"
           "${{ inputs.additional_docker_build_args }}"
-        tags: |
-          ${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:latest
-          ${{ inputs.docker_registry}}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }}
+        tags: ${{ steps.set_tags.outputs.tags }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -15,6 +15,11 @@ on:
         description: Additional docker tag that can be used to specify stable tags
         required: false
         type: string
+      tag_latest:
+        description: Tag docker image as 'latest'
+        required: false
+        type: boolean
+        default: true
       additional_docker_build_args:
           description: Additional docker build arguments
           required: false
@@ -61,6 +66,7 @@ jobs:
           docker_registry: ${{ inputs.docker_registry }}
           registry_org: ${{ inputs.registry_org }}
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
+          tag_latest: ${{ inputs.tag_latest }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
@@ -72,6 +78,7 @@ jobs:
           docker_registry: ${{ inputs.docker_registry }}
           registry_org: ${{ inputs.registry_org }}
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
+          tag_latest: ${{ inputs.tag_latest }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           HMPPS_QUAYIO_USER: ${{ secrets.HMPPS_QUAYIO_USER }}
@@ -87,6 +94,7 @@ jobs:
           docker_registry: ${{ inputs.docker_registry }}
           registry_org: ${{ inputs.registry_org }}
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
+          tag_latest: ${{ inputs.tag_latest }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
@@ -98,6 +106,7 @@ jobs:
           docker_registry: ${{ inputs.docker_registry }}
           registry_org: ${{ inputs.registry_org }}
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
+          tag_latest: ${{ inputs.tag_latest }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -59,7 +59,7 @@ jobs:
       - id: app_version
         name: Application version creators
         uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@v2 # WORKFLOW_VERSION
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@fix-tag-latest # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'ghcr.io' ) && ( ! inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -71,7 +71,7 @@ jobs:
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@fix-tag-latest # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'quay.io' ) && ( ! inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -87,7 +87,7 @@ jobs:
           # git_head_ref: ${{ github.head_ref }}
           # git_branch_ref: ${{ github.ref_name }}
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@fix-tag-latest # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'ghcr.io' ) && ( inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -99,7 +99,7 @@ jobs:
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@fix-tag-latest # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'quay.io' ) && ( inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -59,7 +59,7 @@ jobs:
       - id: app_version
         name: Application version creators
         uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@v2 # WORKFLOW_VERSION
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@fix-tag-latest # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@v2 # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'ghcr.io' ) && ( ! inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -71,7 +71,7 @@ jobs:
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@fix-tag-latest # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@v2 # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'quay.io' ) && ( ! inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -87,7 +87,7 @@ jobs:
           # git_head_ref: ${{ github.head_ref }}
           # git_branch_ref: ${{ github.ref_name }}
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@fix-tag-latest # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@v2 # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'ghcr.io' ) && ( inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -99,7 +99,7 @@ jobs:
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@fix-tag-latest # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_multiplatform_docker@v2 # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'quay.io' ) && ( inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}


### PR DESCRIPTION
- Add optional tag_latest input to the build_docker action to allow building and publishing an image, without making it latest
- Defaults to true to not break any existing use. Overriding value with false will stop the image getting the latest tag
- **(New)** Creates list of docker tags to apply in a step before building/publishing image
- **(New)** Setup for both build_docker and build_multiplatform_docker
