### PR TITLE
Add the ability to upload built images to artifacts and publish them at a later stage

### DIFF
--- a/.github/actions/build-test-and-deploy/build_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_docker/action.yml
@@ -31,6 +31,9 @@ inputs:
     description: Upload image to artifacts in GitHub Actions
     required: false
     default: false
+  image_artifact_retention_days:
+    description: Number of days to keep the image in artifacts
+    required: false
   HMPPS_QUAYIO_USER:
     description: Docker registry username 
     required: false
@@ -116,3 +119,4 @@ runs:
       with:
         name: build_image
         path: ${{ runner.temp }}/build_image.tar
+        retention-days: ${{ inputs.image_artifact_retention_days }}

--- a/.github/actions/build-test-and-deploy/build_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_docker/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Tag image as 'latest'
     required: false
     default: true
+  upload_image_artifact:
+    description: Upload image to artifacts in GitHub Actions
+    required: false
+    default: false
   HMPPS_QUAYIO_USER:
     description: Docker registry username 
     required: false
@@ -99,3 +103,16 @@ runs:
           "${{ inputs.additional_docker_build_args }}"
         tags: ${{ steps.set_tags.outputs.tags }}
 
+    - name: Export image
+      if: ${{ inputs.upload_image_artifact ==  'true' }}
+      id: export_image
+      shell: bash
+      run: docker save ${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}:${{ inputs.app_version }} -o ${{ runner.temp }}/build_image.tar
+
+    - name: Upload image to artifacts
+      if: ${{ inputs.upload_image_artifact ==  'true' }}
+      id: upload_image_artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_image
+        path: ${{ runner.temp }}/build_image.tar

--- a/.github/actions/build-test-and-deploy/build_docker/action.yml
+++ b/.github/actions/build-test-and-deploy/build_docker/action.yml
@@ -20,6 +20,10 @@ inputs:
   push:
     description: Push docker image to registry flag
     required: true
+  load:
+    description: Load docker image into local docker
+    required: false
+    default: false
   app_version: 
     description: App version
     required: true
@@ -98,6 +102,7 @@ runs:
         cache-to: type=gha,mode=max
         context: .
         push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
         provenance: false
         build-args: |
           "BUILD_NUMBER=${{ inputs.app_version }}"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: boolean
         default: false
+      image_artifact_retention_days:
+        description: Number of days to keep the image in artifacts
+        required: false
+        type: number
+        default: 7
       additional_docker_build_args:
           description: Additional docker build arguments
           required: false
@@ -73,6 +78,7 @@ jobs:
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
           tag_latest: ${{ inputs.tag_latest }}
           upload_image_artifact: ${{ inputs.upload_image_artifact }}
+          image_artifact_retention_days: ${{ inputs.image_artifact_retention_days }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
@@ -86,6 +92,7 @@ jobs:
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
           tag_latest: ${{ inputs.tag_latest }}
           upload_image_artifact: ${{ inputs.upload_image_artifact }}
+          image_artifact_retention_days: ${{ inputs.image_artifact_retention_days }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           HMPPS_QUAYIO_USER: ${{ secrets.HMPPS_QUAYIO_USER }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -64,7 +64,7 @@ jobs:
       - id: app_version
         name: Application version creators
         uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@v2 # WORKFLOW_VERSION
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@upload-image-to-artifacts # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'ghcr.io' ) && ( ! inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}
@@ -119,6 +119,3 @@ jobs:
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
           HMPPS_QUAYIO_USER: ${{ secrets.HMPPS_QUAYIO_USER }}
           HMPPS_QUAYIO_TOKEN: ${{ secrets.HMPPS_QUAYIO_TOKEN}}
-
-
-

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -38,6 +38,11 @@ on:
         description: Push docker image to registry flag
         required: true
         type: boolean
+      load:
+        description: Load docker image into local docker
+        required: false
+        type: boolean
+        default: false
       docker_multiplatform:
         description: Docker image build multiplatform or not
         required: true
@@ -80,6 +85,7 @@ jobs:
           upload_image_artifact: ${{ inputs.upload_image_artifact }}
           image_artifact_retention_days: ${{ inputs.image_artifact_retention_days }}
           push: ${{ inputs.push }}
+          load: ${{ inputs.load }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
 
@@ -94,6 +100,7 @@ jobs:
           upload_image_artifact: ${{ inputs.upload_image_artifact }}
           image_artifact_retention_days: ${{ inputs.image_artifact_retention_days }}
           push: ${{ inputs.push }}
+          load: ${{ inputs.load }}
           app_version: ${{ steps.app_version.outputs.version }}
           HMPPS_QUAYIO_USER: ${{ secrets.HMPPS_QUAYIO_USER }}
           HMPPS_QUAYIO_TOKEN: ${{ secrets.HMPPS_QUAYIO_TOKEN}}
@@ -110,6 +117,7 @@ jobs:
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
           tag_latest: ${{ inputs.tag_latest }}
           push: ${{ inputs.push }}
+          load: ${{ inputs.load }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
 
@@ -122,6 +130,7 @@ jobs:
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
           tag_latest: ${{ inputs.tag_latest }}
           push: ${{ inputs.push }}
+          load: ${{ inputs.load }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
           HMPPS_QUAYIO_USER: ${{ secrets.HMPPS_QUAYIO_USER }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: true
+      upload_image_artifact:
+        description: Upload image to artifacts in GitHub Actions
+        required: false
+        type: boolean
+        default: false
       additional_docker_build_args:
           description: Additional docker build arguments
           required: false
@@ -67,6 +72,7 @@ jobs:
           registry_org: ${{ inputs.registry_org }}
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
           tag_latest: ${{ inputs.tag_latest }}
+          upload_image_artifact: ${{ inputs.upload_image_artifact }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           additional_docker_build_args: ${{ inputs.additional_docker_build_args }}
@@ -79,6 +85,7 @@ jobs:
           registry_org: ${{ inputs.registry_org }}
           additional_docker_tag: ${{ inputs.additional_docker_tag }}
           tag_latest: ${{ inputs.tag_latest }}
+          upload_image_artifact: ${{ inputs.upload_image_artifact }}
           push: ${{ inputs.push }}
           app_version: ${{ steps.app_version.outputs.version }}
           HMPPS_QUAYIO_USER: ${{ secrets.HMPPS_QUAYIO_USER }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -74,7 +74,7 @@ jobs:
       - id: app_version
         name: Application version creators
         uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@v2 # WORKFLOW_VERSION
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@upload-image-to-artifacts # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/build_docker@v2 # WORKFLOW_VERSION
         if: ${{ ( inputs.docker_registry  == 'ghcr.io' ) && ( ! inputs.docker_multiplatform )}}
         with:
           repository_name: ${{ github.event.repository.name }}

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -35,6 +35,8 @@ jobs:
   docker_push:
     name: Push docker image
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}
     steps:
       - name: Download docker image
         uses: actions/download-artifact@v4
@@ -61,10 +63,6 @@ jobs:
           registry: ${{ inputs.docker_registry }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
-
-      - name: Set image name
-        shell: bash
-        run: export IMAGE_NAME=${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}
 
       - name: Push image
         shell: bash

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -1,0 +1,78 @@
+name: Push a previously built docker image
+
+on:
+  workflow_call:
+    inputs:
+      docker_registry:
+        description: Docker registry
+        required: true
+        type: string
+      registry_org:
+        description: Docker registry organisation
+        required: true
+        type: string
+      app_version:
+        description: App version
+        required: true
+        type: string
+      tag_latest:
+        description: Tag docker image as 'latest'
+        required: false
+        type: boolean
+        default: true
+
+    secrets:
+      HMPPS_QUAYIO_USER:
+        required: false 
+      HMPPS_QUAYIO_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker_push:
+    name: Push docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: build_image
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/build_image.tar
+
+      - name: Docker login if Docker registry is quay.io
+        if: ${{ inputs.docker_registry  == 'quay.io' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.docker_registry }}
+          username: ${{ secrets.HMPPS_QUAYIO_USER }}
+          password: ${{ secrets.HMPPS_QUAYIO_TOKEN }}
+
+      - name: Docker login if Docker registry is ghcr.io
+        if: ${{ inputs.docker_registry  == 'ghcr.io' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.docker_registry }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set image name
+        shell: bash
+        run: export IMAGE_NAME=${{ inputs.docker_registry }}/${{ inputs.registry_org }}/${{ github.event.repository.name }}
+
+      - name: Push image
+        shell: bash
+        run: docker push "${IMAGE_NAME}:${{ inputs.app_version }}"
+
+      - name: Push latest tag
+        if: ${{ inputs.tag_latest ==  'true' }}
+        shell: bash
+        run: |
+          docker tag "${IMAGE_NAME}:${{ inputs.app_version }}" "${IMAGE_NAME}:latest"
+          docker push "${IMAGE_NAME}:latest"

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -69,7 +69,7 @@ jobs:
         run: docker push "${IMAGE_NAME}:${{ inputs.app_version }}"
 
       - name: Push latest tag
-        if: ${{ inputs.tag_latest ==  'true' }}
+        if: ${{ inputs.tag_latest }}
         shell: bash
         run: |
           docker tag "${IMAGE_NAME}:${{ inputs.app_version }}" "${IMAGE_NAME}:latest"

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -17,9 +17,8 @@ on:
         type: string
       tag_latest:
         description: Tag docker image as 'latest'
-        required: false
+        required: true
         type: boolean
-        default: true
 
     secrets:
       HMPPS_QUAYIO_USER:


### PR DESCRIPTION
This PR enables the following workflow, which is currently supported by the HMPPS CircleCI Orb:

1. Build a Docker image and persist it to Artifacts instead of pushing it to a registry
2. Use the image from Artifacts to stand up a containerised test environment
3. Run end-to-end tests against that image (containerised environment)
4. If the tests pass, push the image to the registry and optionally tag it as "latest"

Example workflow can be found here: https://github.com/ministryofjustice/hmpps-assess-risks-and-needs-oastub-ui/blob/main/.github/workflows/pipeline_main.yml