### PR TITLE
bug/HEAT-577 commit history

### DIFF
--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -62,6 +62,8 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Authenticate
       uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-auth@v2 # WORKFLOW_VERSION
       with:

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -72,7 +72,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: get version history
-      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@bug/FEAT-577_commit_history # WORKFLOW VERSION
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@bug/HEAT-577_commit_history # WORKFLOW VERSION
       if: ${{ inputs.show_changelog }}
       id: version_history
       with:

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -72,7 +72,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: get version history
-      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@v2 # WORKFLOW VERSION
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@bug/FEAT-577_commit_history # WORKFLOW VERSION
       if: ${{ inputs.show_changelog }}
       id: version_history
       with:

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -74,7 +74,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: get version history
-      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@bug/HEAT-577_commit_history # WORKFLOW VERSION
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/version_history@v2 # WORKFLOW VERSION
       if: ${{ inputs.show_changelog }}
       id: version_history
       with:

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -70,7 +70,7 @@ runs:
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
         # Then load it into the variable
         # shellcheck disable=SC2086
-          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  '${PREVIOUS_COMMIT}..${CURRENT_COMMIT}' $CHANGELOG_GIT_PATHS")
+          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  '${PREVIOUS_COMMIT}..${CURRENT_COMMIT}' $CHANGELOG_GIT_PATHS)"
         else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -67,7 +67,7 @@ runs:
       # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
-        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}"
+        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
         # Then load it into the variable
         # shellcheck disable=SC2086
           PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#' \
@@ -76,6 +76,8 @@ runs:
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi
+      echo "Deployment changelog file: $(cat .deployment_changelog)"
+      echo "------------------------------------------"
       echo "Here is the DEPLOYMENT_CHANGELOG: ${DEPLOYMENT_CHANGELOG}"  
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG=${DEPLOYMENT_CHANGELOG}"  >> $GITHUB_OUTPUT

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -68,15 +68,23 @@ runs:
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
         echo "Found previous commit - now getting the diffs"
-        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
-        echo "$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}")"
-        echo "Deployment changelog file:"
+        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .dcla
+        echo "Deployment changelog file so far (.dcl_a):"
         echo "------------------------------------------"
-        cat .deployment_changelog
+        cat .dcl_a
+        echo "------------------------------------------"
+        cat .dcl_a | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g'  > .dcl_b
+        echo "Deployment changelog file so far (.dcl_b):"
+        echo "------------------------------------------"
+        cat .dcl_b
+        echo "------------------------------------------"
+        cat .dcl_b | tr '"' "'" | tr "\`" "'" > .dcl_c
+        echo "------------------------------------------"
+        cat .dcl_c
         echo "------------------------------------------"
         # Then load it into the variable
         echo "Loading the difference into DEPLOYMENT_CHANGELOG"
-        DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS)"
+        DEPLOYMENT_CHANGELOG="cat ${.dcl_c}"
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -71,7 +71,7 @@ runs:
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
-          | tr '"' "'" | tr "\`" "'"  `
+          | tr '"' "'" | tr "\`" "'"  \
           | sed ':a;N;$!ba;s/\n/\\n/g' \ 
           >> .deployment_changelog
       else

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -67,16 +67,12 @@ runs:
       # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
-        PAGER="cat" git log --oneline --no-decorate \
-          --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
-          "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' | tr '"' "'" | tr "\`" "'"
+        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}"
         # Then load it into the variable
         # shellcheck disable=SC2086
-          PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate \
-          --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
+          PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' | tr '"' "'" | tr "\`" "'")"
+          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g')"
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -46,7 +46,7 @@ runs:
 
       # initialise the changelog
       echo "Touching .deployment_changelog"
-      touch .dcl_a .dcl_b .dcl_c .dlc_d
+      touch /tmp/.dcl_a /tmp/.dcl_b /tmp/.dcl_c /tmp/.dlc_d
  
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
       K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
@@ -69,29 +69,31 @@ runs:
         # Run the actual thing so we can see what it's doing
         echo "Found previous commit - now getting the diffs"
         echo "Processing change log using files"
-        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .dcla
-        echo "Deployment changelog file so far (.dcl_a):"
+        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> /tmp/.dcla
+        echo "Deployment changelog file so far (/tmp/.dcl_a):"
         echo "------------------------------------------"
-        cat .dcl_a
+        cat /tmp/.dcl_a
         echo "------------------------------------------"
-        cat .dcl_a | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g'  > .dcl_b
-        echo "Deployment changelog file so far (.dcl_b):"
+        cat .dcl_a | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g'  > /tmp/.dcl_b
+        echo "Deployment changelog file so far (/tmp/.dcl_b):"
         echo "------------------------------------------"
-        cat .dcl_b
+        cat /tmp/.dcl_b
         echo "------------------------------------------"
-        cat .dcl_b | tr '"' "'" | tr "\`" "'" > .dcl_c
-        echo "Deployment changelog file so far (.dcl_c):"
+        cat /tmp/.dcl_b | tr '"' "'" | tr "\`" "'" > /tmp/.dcl_c
+        echo "Deployment changelog file so far (/tmp/.dcl_c):"
         echo "------------------------------------------"
-        cat .dcl_c
+        cat /tmp/.dcl_c
         echo "------------------------------------------"
-        cat .dcl_c | sed ':a;N;$!ba;s/\n/\\n/g' > .dcl_d
-        echo "Deployment changelog file so far (.dcl_d):"
+        cat /tmp/.dcl_c | sed ':a;N;$!ba;s/\n/\\n/g' > /tmp/.dcl_d
+        echo "Deployment changelog file so far (/tmp/.dcl_d):"
         echo "------------------------------------------"
-        cat .dcl_d
+        cat /tmp/.dcl_d
         echo "------------------------------------------"       
         # Then load it into the variable
         echo "Loading the difference into DEPLOYMENT_CHANGELOG"
-        DEPLOYMENT_CHANGELOG="$(cat ${.dcl_d})"
+        DEPLOYMENT_CHANGELOG="$(cat /tmp/.dcl_d)"
+        # Finally clear out the files
+        rm -f /tmp/.dcl*
 
         # Separate section to deal with the variable alternative
         echo "Processing change log using variables"

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -70,9 +70,7 @@ runs:
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
         # Then load it into the variable
         # shellcheck disable=SC2086
-          PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#' \
-          "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g')"
+          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  '${PREVIOUS_COMMIT}..${CURRENT_COMMIT}' $CHANGELOG_GIT_PATHS"
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -67,17 +67,15 @@ runs:
       # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # shellcheck disable=SC2086
-          PAGER="cat" git log --oneline --no-decorate \
+          PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
-          | tr '"' "'" | tr "\`" "'" | sed ':a;N;$!ba;s/\n/\\n/g' >> .deployment_changelog
+          | tr '"' "'" | tr "\`" "'" | sed ':a;N;$!ba;s/\n/\\n/g')"
       else
-        echo "Changelog not available." > .deployment_changelog
+        DEPLOYMENT_CHANGELOG="Changelog not available."
       fi
-      echo "Here is the DEPLOYMENT_CHANGELOG"
+      echo "Here is the DEPLOYMENT_CHANGELOG: ${DEPLOYMENT_CHANGELOG}"  
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     
-      echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog)"  >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=${DEPLOYMENT_CHANGELOG}"  >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -46,8 +46,8 @@ runs:
 
       # initialise the changelog
       echo "Touching .deployment_changelog"
-      touch .deployment_changelog
-
+      touch .dcl_a .dcl_b .dcl_c .dlc_d
+ 
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
       K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
       echo "CURRENT_COMMIT=${CURRENT_COMMIT}"

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -43,10 +43,6 @@ runs:
       else
         K8S_DEPLOYMENT_NAME="${{ inputs.k8s_deployment_name }}"
       fi
-
-      # initialise the changelog
-      echo "Touching .deployment_changelog"
-      touch /tmp/.dcl_a /tmp/.dcl_b /tmp/.dcl_c /tmp/.dlc_d
  
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
       K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
@@ -68,45 +64,13 @@ runs:
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
         echo "Found previous commit - now getting the diffs"
-        echo "Processing change log using files"
-        PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> /tmp/.dcla
-        echo "Deployment changelog file so far (/tmp/.dcl_a):"
-        echo "------------------------------------------"
-        cat /tmp/.dcl_a
-        echo "------------------------------------------"
-        cat /tmp/.dcl_a | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g'  > /tmp/.dcl_b
-        echo "Deployment changelog file so far (/tmp/.dcl_b):"
-        echo "------------------------------------------"
-        cat /tmp/.dcl_b
-        echo "------------------------------------------"
-        cat /tmp/.dcl_b | tr '"' "'" | tr "\`" "'" > /tmp/.dcl_c
-        echo "Deployment changelog file so far (/tmp/.dcl_c):"
-        echo "------------------------------------------"
-        cat /tmp/.dcl_c
-        echo "------------------------------------------"
-        cat /tmp/.dcl_c | sed ':a;N;$!ba;s/\n/\\n/g' > /tmp/.dcl_d
-        echo "Deployment changelog file so far (/tmp/.dcl_d):"
-        echo "------------------------------------------"
-        cat /tmp/.dcl_d
-        echo "------------------------------------------"       
-        # Then load it into the variable
-        echo "Loading the difference into DEPLOYMENT_CHANGELOG"
-        DEPLOYMENT_CHANGELOG="$(cat /tmp/.dcl_d)"
-        # Finally clear out the files
-        rm -f /tmp/.dcl_*
-
-        # Separate section to deal with the variable alternative
-        echo "Processing change log using variables"
         dcl_a="$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}")"
         echo "dcl_a=${dcl_a}"
         dcl_b="$(echo "${dcl_a}" | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g')"
         echo "dcl_b=${dcl_b}"  
         dcl_c="$(echo "${dcl_b}" | tr '"' "'" | tr "\`" "'")"
         echo "dcl_c=${dcl_c}"
-        dcl_d="$(echo "${dcl_c}" | sed ':a;N;$!ba;s/\n/\\n/g')"
-        echo "dcl_d=${dcl_d}"
-        echo "DEPLOYMENT_CHANGELOG could be: ${dcl_d}"
-
+        DEPLOYMENT_CHANGELOG="$(echo "${dcl_c}" | sed ':a;N;$!ba;s/\n/\\n/g')"
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -70,8 +70,8 @@ runs:
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
         # Then load it into the variable
         # shellcheck disable=SC2086
-          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  '${PREVIOUS_COMMIT}..${CURRENT_COMMIT}' $CHANGELOG_GIT_PATHS"
-      else
+          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  '${PREVIOUS_COMMIT}..${CURRENT_COMMIT}' $CHANGELOG_GIT_PATHS")
+        else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi
       echo "Deployment changelog file: $(cat .deployment_changelog)"

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -70,7 +70,7 @@ runs:
         PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' tr '"' "'" | tr "\`" "'"
+          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' | tr '"' "'" | tr "\`" "'"
         # Then load it into the variable
         # shellcheck disable=SC2086
           PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate \

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -66,12 +66,17 @@ runs:
       # Check $PREVIOUS_COMMIT sha1 is valid
       # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
+        # Run the actual thing so we can see what it's doing
+        PAGER="cat" git log --oneline --no-decorate \
+          --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
+          "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
+          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' tr '"' "'" | tr "\`" "'"
+        # Then load it into the variable
         # shellcheck disable=SC2086
           PAGER="cat" DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
-          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
-          | tr '"' "'" | tr "\`" "'" | sed ':a;N;$!ba;s/\n/\\n/g')"
+          | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' | tr '"' "'" | tr "\`" "'")"
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -77,11 +77,9 @@ runs:
       else
         echo "Changelog not available." > .deployment_changelog
       fi
-      echo
       echo "Here is the DEPLOYMENT_CHANGELOG"
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     
-      echo "------------------------------------------"
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog  >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -70,7 +70,7 @@ runs:
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
         # Then load it into the variable
         # shellcheck disable=SC2086
-          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  '${PREVIOUS_COMMIT}..${CURRENT_COMMIT}' $CHANGELOG_GIT_PATHS)"
+          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS)"
         else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -64,28 +64,24 @@ runs:
       # Some apps may not have set the correct k8s label with a valid app version containing a sha1
 
       # Check $PREVIOUS_COMMIT sha1 is valid
+      # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # shellcheck disable=SC2086
         PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
-          | tr '"' "'" | tr "\`" "'" \
+          | tr '"' "'" | tr "\`" "'"  `
+          | sed ':a;N;$!ba;s/\n/\\n/g' \ 
           >> .deployment_changelog
       else
         echo "Changelog not available." > .deployment_changelog
       fi
-      echo "(debug) cat the .deployment_changelog file:"
-      cat .deployment_changelog
       echo
-      echo "Here is the unprocessed DEPLOYMENT_CHANGELOG"
+      echo "Here is the DEPLOYMENT_CHANGELOG"
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     
       echo "------------------------------------------"
-      echo
-      echo "Here is the processed DEPLOYMENT_CHANGELOG - should not have double quotes or backticks"
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')"
-      echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog | sed ':a;N;$!ba;s/\n/\\n/g')" >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog  >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -49,7 +49,7 @@ runs:
       touch .deployment_changelog
 
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
-      K8S_PREVIOUS_APP_VERSION="$(expokubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
+      K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
       echo "CURRENT_COMMIT=${CURRENT_COMMIT}"
       echo "K8S_PREVIOUS_APP_VERSION=${K8S_PREVIOUS_APP_VERSION}"      
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -81,5 +81,5 @@ runs:
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     
       echo "------------------------------------------"
-      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog  >> $GITHUB_OUTPUT
+      echo "DEPLOYMENT_CHANGELOG=$(cat .deployment_changelog)"  >> $GITHUB_OUTPUT
 

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -74,7 +74,7 @@ runs:
         echo "------------------------------------------"
         cat /tmp/.dcl_a
         echo "------------------------------------------"
-        cat .dcl_a | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g'  > /tmp/.dcl_b
+        cat /tmp/.dcl_a | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g'  > /tmp/.dcl_b
         echo "Deployment changelog file so far (/tmp/.dcl_b):"
         echo "------------------------------------------"
         cat /tmp/.dcl_b
@@ -93,7 +93,7 @@ runs:
         echo "Loading the difference into DEPLOYMENT_CHANGELOG"
         DEPLOYMENT_CHANGELOG="$(cat /tmp/.dcl_d)"
         # Finally clear out the files
-        rm -f /tmp/.dcl*
+        rm -f /tmp/.dcl_*
 
         # Separate section to deal with the variable alternative
         echo "Processing change log using variables"

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -70,7 +70,7 @@ runs:
         echo "Found previous commit - now getting the diffs"
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
         echo "$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}")"
-        echo "Deployment changelog file: 
+        echo "Deployment changelog file:"
         echo "------------------------------------------"
         cat .deployment_changelog
         echo "------------------------------------------"

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -75,7 +75,9 @@ runs:
       else
         echo "Changelog not available." > .deployment_changelog
       fi
-
+      echo "(debug) cat the .deployment_changelog file:"
+      cat .deployment_changelog
+      echo
       echo "Here is the unprocessed DEPLOYMENT_CHANGELOG"
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG='$(cat .deployment_changelog)'"     

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -64,13 +64,11 @@ runs:
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
         echo "Found previous commit - now getting the diffs"
-        dcl_a="$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}")"
+        dcl_a="$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}"| sed ':a;N;$!ba;s/\n/\\n/g')"
         echo "dcl_a=${dcl_a}"
         dcl_b="$(echo "${dcl_a}" | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g')"
         echo "dcl_b=${dcl_b}"  
-        dcl_c="$(echo "${dcl_b}" | tr '"' "'" | tr "\`" "'")"
-        echo "dcl_c=${dcl_c}"
-        DEPLOYMENT_CHANGELOG="$(echo "${dcl_c}" | sed ':a;N;$!ba;s/\n/\\n/g')"
+        DEPLOYMENT_CHANGELOG="$(echo "${dcl_b}" | tr '"' "'" | tr "\`" "'")"
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -67,15 +67,19 @@ runs:
       # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
+        echo "Found previous commit - now getting the diffs"
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .deployment_changelog
+        echo "$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)'  --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}")"
+        echo "Deployment changelog file: 
+        echo "------------------------------------------"
+        cat .deployment_changelog
+        echo "------------------------------------------"
         # Then load it into the variable
-        # shellcheck disable=SC2086
-          DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS)"
-        else
+        echo "Loading the difference into DEPLOYMENT_CHANGELOG"
+        DEPLOYMENT_CHANGELOG="$(git log --oneline --no-decorate --pretty=format:'%h %s (%cr)' --grep='#'  "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS)"
+      else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi
-      echo "Deployment changelog file: $(cat .deployment_changelog)"
-      echo "------------------------------------------"
       echo "Here is the DEPLOYMENT_CHANGELOG: ${DEPLOYMENT_CHANGELOG}"  
       echo "------------------------------------------"
       echo "DEPLOYMENT_CHANGELOG=${DEPLOYMENT_CHANGELOG}"  >> $GITHUB_OUTPUT

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -49,7 +49,7 @@ runs:
       touch .deployment_changelog
 
       CURRENT_COMMIT="$(echo "${{ inputs.app_version }}" | cut -d'.' -f3)" 
-      K8S_PREVIOUS_APP_VERSION="$(kubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
+      K8S_PREVIOUS_APP_VERSION="$(expokubectl get "deployment/${K8S_DEPLOYMENT_NAME}" --namespace="${{ inputs.namespace }}" -o=jsonpath='{.metadata.labels.app\.kubernetes\.io/version}' || true)"
       echo "CURRENT_COMMIT=${CURRENT_COMMIT}"
       echo "K8S_PREVIOUS_APP_VERSION=${K8S_PREVIOUS_APP_VERSION}"      
 
@@ -71,8 +71,7 @@ runs:
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
-          | tr '"' "'" | tr "\`" "'" | sed ':a;N;$!ba;s/\n/\\n/g' \ 
-          >> .deployment_changelog
+          | tr '"' "'" | tr "\`" "'" | sed ':a;N;$!ba;s/\n/\\n/g' >> .deployment_changelog
       else
         echo "Changelog not available." > .deployment_changelog
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -68,6 +68,7 @@ runs:
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # Run the actual thing so we can see what it's doing
         echo "Found previous commit - now getting the diffs"
+        echo "Processing change log using files"
         PAGER="cat" git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" >> .dcla
         echo "Deployment changelog file so far (.dcl_a):"
         echo "------------------------------------------"
@@ -79,12 +80,31 @@ runs:
         cat .dcl_b
         echo "------------------------------------------"
         cat .dcl_b | tr '"' "'" | tr "\`" "'" > .dcl_c
+        echo "Deployment changelog file so far (.dcl_c):"
         echo "------------------------------------------"
         cat .dcl_c
         echo "------------------------------------------"
+        cat .dcl_c | sed ':a;N;$!ba;s/\n/\\n/g' > .dcl_d
+        echo "Deployment changelog file so far (.dcl_d):"
+        echo "------------------------------------------"
+        cat .dcl_d
+        echo "------------------------------------------"       
         # Then load it into the variable
         echo "Loading the difference into DEPLOYMENT_CHANGELOG"
-        DEPLOYMENT_CHANGELOG="cat ${.dcl_c}"
+        DEPLOYMENT_CHANGELOG="$(cat ${.dcl_d})"
+
+        # Separate section to deal with the variable alternative
+        echo "Processing change log using variables"
+        dcl_a="$(git log --oneline --no-decorate  --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}")"
+        echo "dcl_a=${dcl_a}"
+        dcl_b="$(echo "${dcl_a}" | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g')"
+        echo "dcl_b=${dcl_b}"  
+        dcl_c="$(echo "${dcl_b}" | tr '"' "'" | tr "\`" "'")"
+        echo "dcl_c=${dcl_c}"
+        dcl_d="$(echo "${dcl_c}" | sed ':a;N;$!ba;s/\n/\\n/g')"
+        echo "dcl_d=${dcl_d}"
+        echo "DEPLOYMENT_CHANGELOG could be: ${dcl_d}"
+
       else
         DEPLOYMENT_CHANGELOG="Changelog not available."
       fi

--- a/.github/actions/version_history/action.yml
+++ b/.github/actions/version_history/action.yml
@@ -67,12 +67,11 @@ runs:
       # Add the sed command to the end of this so it is only one line
       if git rev-parse --quiet --verify "${PREVIOUS_COMMIT}" &>/dev/null; then
         # shellcheck disable=SC2086
-        PAGER="cat" git log --oneline --no-decorate \
+          PAGER="cat" git log --oneline --no-decorate \
           --pretty=format:'%h %s (%cr)' --committer='noreply@github.com' --grep='#' \
           "${PREVIOUS_COMMIT}..${CURRENT_COMMIT}" $CHANGELOG_GIT_PATHS \
           | sed 's/Merge pull request /PR /g; s|from ministryofjustice/dependabot/|:dependabot:|g; s|from ministryofjustice/||g' \
-          | tr '"' "'" | tr "\`" "'"  \
-          | sed ':a;N;$!ba;s/\n/\\n/g' \ 
+          | tr '"' "'" | tr "\`" "'" | sed ':a;N;$!ba;s/\n/\\n/g' \ 
           >> .deployment_changelog
       else
         echo "Changelog not available." > .deployment_changelog

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -76,7 +76,7 @@ jobs:
             echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           fi
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@bug/HEAT-577_commit_history # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
         id: deploy
         with:
           environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -76,7 +76,7 @@ jobs:
             echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           fi
 
-      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@v2 # WORKFLOW_VERSION
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-deploy@bug/HEAT-577_commit_history # WORKFLOW_VERSION
         id: deploy
         with:
           environment: ${{ inputs.environment }}


### PR DESCRIPTION
Turns out this was for two reasons:
- the file wasn't being picked up properly; I've changed it to use variables now
- the cloud-platform-deploy composite action had an extra checkout, which didn't have the `fetch-depth: 0` required to get the entire commit history.

Fixed and validated. 