### PR TITLE
bug/HEAT-589 sanitise commit messages for use in Slack

### DIFF
--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -39,8 +39,10 @@ runs:
       if commit_message:
         first_line=commit_message.split('\n')[0][:256]
         sanitised_message = re.sub(pattern, '', first_line)
-        print(f'commit_message_first_line={sanitised_message}')
-    shell: python {0} >> $GITHUB_ENV
+        with open(os.getenv('GITHUB_ENV'), 'a') as gh_env:
+        gh_env.write(f'commit_message_first_line={truncated_message}\n')
+        gh_env.close()
+    shell: python {0}
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 

--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -24,12 +24,26 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: First line of slack commit only.
-    shell: bash
-    run: echo "commit_message_first_line=${{ github.event.head_commit.message }}" | head -n 1 >> $GITHUB_ENV
-  - name: Debug the changelog
-    shell: bash
-    run: echo "deployment_changelog is as follows - ${{ inputs.deployment_changelog }}"
+  - name: Set up Python
+    uses: actions/setup-python@v2
+    with:
+      python-version: '3.x'
+  - name: Sanitised first line of commit message
+    run: |
+      import os
+      import re
+      remove_chars='{}()><&*‘|=?;[]$–#~!.%"\\/:+,`-'
+      pattern = f'[{re.escape(remove_chars)}]'
+      commit_message=os.getenv('COMMIT_MESSAGE','')
+      # First line of commit message (and first 256 lines if longer)
+      if commit_message:
+        first_line=commit_message.split('\n')[0][:256]
+        sanitised_message = re.sub(pattern, '', first_line)
+        print(f'commit_message_first_line={sanitised_message}')
+    shell: python {0} >> $GITHUB_ENV
+    env:
+      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+
   - name: Slack - Send a message
     id: slack-release-message
     uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0

--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -40,7 +40,7 @@ runs:
         first_line=commit_message.split('\n')[0][:256]
         sanitised_message = re.sub(pattern, '', first_line)
         with open(os.getenv('GITHUB_ENV'), 'a') as gh_env:
-          gh_env.write(f'commit_message_first_line={truncated_message}\n')
+          gh_env.write(f'commit_message_first_line={sanitised_message}\n')
         gh_env.close()
     shell: python {0}
     env:

--- a/.github/actions/slack_release_results/action.yml
+++ b/.github/actions/slack_release_results/action.yml
@@ -40,7 +40,7 @@ runs:
         first_line=commit_message.split('\n')[0][:256]
         sanitised_message = re.sub(pattern, '', first_line)
         with open(os.getenv('GITHUB_ENV'), 'a') as gh_env:
-        gh_env.write(f'commit_message_first_line={truncated_message}\n')
+          gh_env.write(f'commit_message_first_line={truncated_message}\n')
         gh_env.close()
     shell: python {0}
     env:


### PR DESCRIPTION
This uses Python to parse the commit message so it's a bit safer to be sent to Slack 