### PR TITLE
feat/HEAT-592 GitHub actions scans

### DIFF
--- a/.github/workflows/security_codeql_actions.yml
+++ b/.github/workflows/security_codeql_actions.yml
@@ -1,0 +1,45 @@
+name: Security CodeQL Githuh Actions scan
+
+on:
+  workflow_call:
+    inputs:
+      channel_id:
+        description: 'The slack channel ID to send a message on failure. If this is not provided then no message is sent.'
+        required: false
+        default: 'NO_SLACK'
+        type: string
+    secrets:
+      HMPPS_SRE_SLACK_BOT_TOKEN:
+        description: 'Slack bot token'
+        required: false
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security-codeql-check:
+    name: Security CodeQL Github Actions scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: actions 
+    - name: Perform CodeQL Analysis
+      id: codeql_analysis
+      uses: github/codeql-action/analyze@v2
+    - name: CodeQL slack notification
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_codescan_notification@v2 # WORKFLOW_VERSION
+      if: (failure() || steps.codeql_analysis.outcome == 'failure') && inputs.channel_id != 'NO_SLACK'
+      with:
+        title: "CodeQL Actions Scan"
+        warningOnly: ${{ steps.codeql_analysis.outcome == 'success' }}
+        channel_id: ${{ inputs.channel_id}}
+        SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security_codeql_actions.yml
+++ b/.github/workflows/security_codeql_actions.yml
@@ -18,7 +18,7 @@ permissions:
   security-events: write
 
 jobs:
-  security-codeql-check:
+  security-codeql-scan:
     name: Security CodeQL Github Actions scan
     runs-on: ubuntu-latest
     permissions:
@@ -35,6 +35,20 @@ jobs:
     - name: Perform CodeQL Analysis
       id: codeql_analysis
       uses: github/codeql-action/analyze@v3
+    - name: upload CodeQL artifact
+      uses: actions/upload-artifact@v4
+      id: codeql-upload-artifact
+      with:
+        name: codeql-check-${{ github.event.repository.name }}
+        path: codeql-results.sarif
+      continue-on-error: true
+    - name: CodeQL upload sarif
+      id: codeql-upload
+      if: ${{ github.event.repository.visibility != 'private' && github.event.repository.visibility != 'internal' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: 'codeql-results.sarif'
+        category: actions-codeql-check
     - name: CodeQL slack notification
       uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_codescan_notification@v2 # WORKFLOW_VERSION
       if: (failure() || steps.codeql_analysis.outcome == 'failure') && inputs.channel_id != 'NO_SLACK'

--- a/.github/workflows/security_codeql_actions.yml
+++ b/.github/workflows/security_codeql_actions.yml
@@ -35,20 +35,6 @@ jobs:
     - name: Perform CodeQL Analysis
       id: codeql_analysis
       uses: github/codeql-action/analyze@v3
-    - name: upload CodeQL artifact
-      uses: actions/upload-artifact@v4
-      id: codeql-upload-artifact
-      with:
-        name: codeql-check-${{ github.event.repository.name }}
-        path: codeql-results.sarif
-      continue-on-error: true
-    - name: CodeQL upload sarif
-      id: codeql-upload
-      if: ${{ github.event.repository.visibility != 'private' && github.event.repository.visibility != 'internal' }}
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'codeql-results.sarif'
-        category: actions-codeql-check
     - name: CodeQL slack notification
       uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_codescan_notification@v2 # WORKFLOW_VERSION
       if: (failure() || steps.codeql_analysis.outcome == 'failure') && inputs.channel_id != 'NO_SLACK'

--- a/.github/workflows/security_codeql_actions.yml
+++ b/.github/workflows/security_codeql_actions.yml
@@ -29,12 +29,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: actions 
     - name: Perform CodeQL Analysis
       id: codeql_analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
     - name: CodeQL slack notification
       uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_codescan_notification@v2 # WORKFLOW_VERSION
       if: (failure() || steps.codeql_analysis.outcome == 'failure') && inputs.channel_id != 'NO_SLACK'

--- a/templates/workflows/security_npm_dependency.yml
+++ b/templates/workflows/security_npm_dependency.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "30 5 * * MON-FRI" # Every weekday at 05:35 UTC
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-npm-dependency-check:
     name: Project security npm dependency check

--- a/templates/workflows/security_owasp.yml
+++ b/templates/workflows/security_owasp.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
-
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-kotlin-owasp-check:
     name: Kotlin security OWASP dependency check

--- a/templates/workflows/security_trivy.yml
+++ b/templates/workflows/security_trivy.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 5 * * MON-FRI" # Every weekday at 05:30 UTC
-
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-trivy-check:
     name: Project security trivy dependency check

--- a/templates/workflows/security_veracode_pipeline_scan.yml
+++ b/templates/workflows/security_veracode_pipeline_scan.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "35 5 * * MON-FRI" # Every weekday at 05:35 UTC
-
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-veracode-pipeline-scan:
     name: Project security veracode pipeline scan

--- a/templates/workflows/security_veracode_policy_scan.yml
+++ b/templates/workflows/security_veracode_policy_scan.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 5 * * 1" # Every Monday at 03:50 UTC
-
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 jobs:
   security-veracode-policy-check:
     name: Project security veracode policy scan


### PR DESCRIPTION
This adds a CodeQL scan to github actions for Github actions within a repository, which gets added to the Security Code Scanning section of a repo.

Once this is in place, I'll implement it for the Portfolio Management projects to shake down the various actions..

Also adds the requisite permissions to the template scans