### PR TITLE
SDIT-2737: 👷 Add in gradle helper workflows

### DIFF
--- a/.github/workflows/gradle_localstack_postgres_verify.yml
+++ b/.github/workflows/gradle_localstack_postgres_verify.yml
@@ -29,7 +29,7 @@ on:
         type: string
         default: './gradlew check'
         required: false
-      services:
+      localstack-services:
         type: string
         default: 'sqs,sns'
         required: false
@@ -44,29 +44,35 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        # Docker Hub PostgreSQL image
         image: postgres:${{ inputs.postgres-tag }}
-        # Provide the configuration for postgres
         env:
           POSTGRES_USER: ${{ inputs.postgres-username }}
           POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
           POSTGRES_DB: ${{ inputs.postgres-db}}
         options: >-
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
-          # Maps tcp port 5432 on service container to the host
           - 5432:5432
       localstack:
         image: localstack/localstack:${{ inputs.localstack-tag }}
-        ports:
-          - 4566:4566
-          - 4571:4571
         env:
           ES_PORT_EXTERNAL: 4571
           DOCKER_HOST: 'unix:///var/run/docker.sock'
           AWS_EXECUTION_ENV: True
           PERSISTENCE: 1
-          SERVICES: "${{ inputs.services }}"
+          SERVICES: "${{ inputs.localstack-services }}"
+        options: >-
+          --name localstack
+          --health-cmd "curl -sS 127.0.0.1:4566 || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 4566:4566
+          - 4571:4571
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/gradle_localstack_postgres_verify.yml
+++ b/.github/workflows/gradle_localstack_postgres_verify.yml
@@ -1,0 +1,92 @@
+name: Run gradle checks with localstack and postgres instances
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        type: string
+        required: false
+        default: '21'
+      java-options:
+        type: string
+        default: ''
+        required: false
+      postgres-tag:
+        type: string
+        required: true
+      postgres-password:
+        type: string
+        default: 'dev'
+        required: false
+      postgres-username:
+        type: string
+        default: 'root'
+        required: true
+      postgres-db:
+        type: string
+        default: 'postgres'
+        required: false
+      gradle-command:
+        type: string
+        default: './gradlew check'
+        required: false
+      services:
+        type: string
+        default: 'sqs,sns'
+        required: false
+      localstack-tag:
+        type: string
+        default: 'latest'
+        required: false
+permissions:
+  contents: read
+jobs:
+  gradle-localstack-postgres-verify:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        # Docker Hub PostgreSQL image
+        image: postgres:${{ inputs.postgres-tag }}
+        # Provide the configuration for postgres
+        env:
+          POSTGRES_USER: ${{ inputs.postgres-username }}
+          POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
+          POSTGRES_DB: ${{ inputs.postgres-db}}
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+      localstack:
+        image: localstack/localstack:${{ inputs.localstack-tag }}
+        ports:
+          - 4566:4566
+          - 4571:4571
+        env:
+          ES_PORT_EXTERNAL: 4571
+          DOCKER_HOST: 'unix:///var/run/docker.sock'
+          AWS_EXECUTION_ENV: True
+          PERSISTENCE: 1
+          SERVICES: "${{ inputs.services }}"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '${{ inputs.java-version }}'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run checks with gradle
+        shell: bash
+        run: |
+          export JAVA_OPTS="${{ inputs.java-options }}"
+          ${{ inputs.gradle-command }}
+      - name: Upload the artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upload test results
+          path: |
+            build/test-results
+            build/reports/tests

--- a/.github/workflows/gradle_localstack_verify.yml
+++ b/.github/workflows/gradle_localstack_verify.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: './gradlew check'
         required: false
-      services:
+      localstack-services:
         type: string
         default: 'sqs,sns'
         required: false
@@ -31,15 +31,21 @@ jobs:
     services:
       localstack:
         image: localstack/localstack:${{ inputs.localstack-tag }}
-        ports:
-          - 4566:4566
-          - 4571:4571
         env:
           ES_PORT_EXTERNAL: 4571
           DOCKER_HOST: 'unix:///var/run/docker.sock'
           AWS_EXECUTION_ENV: True
           PERSISTENCE: 1
-          SERVICES: "${{ inputs.services }}"
+          SERVICES: "${{ inputs.localstack-services }}"
+        options: >-
+          --name localstack
+          --health-cmd "curl -sS 127.0.0.1:4566 || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 4566:4566
+          - 4571:4571
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/gradle_localstack_verify.yml
+++ b/.github/workflows/gradle_localstack_verify.yml
@@ -1,0 +1,65 @@
+name: Run gradle checks with a localstack instance
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        type: string
+        required: false
+        default: '21'
+      java-options:
+        type: string
+        default: ''
+        required: false
+      gradle-command:
+        type: string
+        default: './gradlew check'
+        required: false
+      services:
+        type: string
+        default: 'sqs,sns'
+        required: false
+      localstack-tag:
+        type: string
+        default: 'latest'
+        required: false
+permissions:
+  contents: read
+jobs:
+  gradle-localstack-verify:
+    name: Verify the gradle app with localstack running
+    runs-on: ubuntu-latest
+    services:
+      localstack:
+        image: localstack/localstack:${{ inputs.localstack-tag }}
+        ports:
+          - 4566:4566
+          - 4571:4571
+        env:
+          ES_PORT_EXTERNAL: 4571
+          DOCKER_HOST: 'unix:///var/run/docker.sock'
+          AWS_EXECUTION_ENV: True
+          PERSISTENCE: 1
+          SERVICES: "${{ inputs.services }}"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '${{ inputs.java-version }}'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run checks with gradle
+        shell: bash
+        run: |
+          export JAVA_OPTS="${{ inputs.java-options }}"
+          ${{ inputs.gradle-command }}
+      - name: Upload the artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upload test results
+          path: |
+            build/test-results
+            build/reports/tests

--- a/.github/workflows/gradle_postgres_verify.yml
+++ b/.github/workflows/gradle_postgres_verify.yml
@@ -1,0 +1,73 @@
+name: Run gradle checks with a postgres instances
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        type: string
+        required: false
+        default: '21'
+      java-options:
+        type: string
+        default: ''
+        required: false
+      postgres-tag:
+        type: string
+        required: true
+      postgres-password:
+        type: string
+        default: 'dev'
+        required: false
+      postgres-username:
+        type: string
+        default: 'root'
+        required: true
+      postgres-db:
+        type: string
+        default: 'postgres'
+        required: false
+      gradle-command:
+        type: string
+        default: './gradlew check'
+        required: false
+permissions:
+  contents: read
+jobs:
+  gradle-postgres-verify:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        # Docker Hub PostgreSQL image
+        image: postgres:${{ inputs.postgres-tag }}
+        # Provide the configuration for postgres
+        env:
+          POSTGRES_USER: ${{ inputs.postgres-username }}
+          POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
+          POSTGRES_DB: ${{ inputs.postgres-db}}
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '${{ inputs.java-version }}'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run checks with gradle
+        shell: bash
+        run: |
+          export JAVA_OPTS="${{ inputs.java-options }}"
+          ${{ inputs.gradle-command }}
+      - name: Upload the artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upload test results
+          path: |
+            build/test-results
+            build/reports/tests

--- a/.github/workflows/gradle_postgres_verify.yml
+++ b/.github/workflows/gradle_postgres_verify.yml
@@ -36,17 +36,17 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        # Docker Hub PostgreSQL image
         image: postgres:${{ inputs.postgres-tag }}
-        # Provide the configuration for postgres
         env:
           POSTGRES_USER: ${{ inputs.postgres-username }}
           POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
           POSTGRES_DB: ${{ inputs.postgres-db}}
         options: >-
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
-          # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
       - name: Checkout sources

--- a/.github/workflows/gradle_verify.yml
+++ b/.github/workflows/gradle_verify.yml
@@ -1,0 +1,45 @@
+name: Run gradle checks
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        type: string
+        required: false
+        default: '21'
+      java-options:
+        type: string
+        default: ''
+        required: false
+      gradle-command:
+        type: string
+        default: './gradlew check'
+        required: false
+permissions:
+  contents: read
+jobs:
+  gradle-verify:
+    name: Verify the gradle app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '${{ inputs.java-version }}'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run checks with gradle
+        shell: bash
+        run: |
+          export JAVA_OPTS="${{ inputs.java-options }}"
+          ${{ inputs.gradle-command }}
+      - name: Upload the artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upload test results
+          path: |
+            build/test-results
+            build/reports/tests


### PR DESCRIPTION
New gradle workflows that do the following:
1. Default the java options to empty string - haven't needed to set this since moving to github actions anyway
2. Uses [gradle/actions/setup-gradle](https://github.com/gradle/actions) to setup gradle, validate the wrapper and configure cache settings
3. Allow `gradle-command` to be overridden by calling jobs
4. Provide additional workflows for localstack and postgres configurations