### PR TITLE
Include options for trivy scans so that we can report on unfixed vulnerabilities

### DIFF
--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         image-ref: "${{ env.repo }}/${{ inputs.subproject == '' && github.event.repository.name || inputs.subproject}}:latest"
         severity: 'HIGH,CRITICAL'
-        ignore-unfixed: true
+        ignore-unfixed: false
         skip-dirs: '/usr/local/lib/node_modules/npm'
         skip-files: /app/agent.jar
         format: 'sarif'

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -23,7 +23,7 @@ on:
         required: false
         default: 'HIGH,CRITICAL'
         type: string
-      limit-severities-for-sarif:
+      limit_severities_for_sarif:
         description: 'only includes severities as defined in the sarif file'
         required: false
         default: true
@@ -64,7 +64,7 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: 1
-        limit-severities-for-sarif: ${{ inputs.limit-severities-for-sarif }}
+        limit-severities-for-sarif: ${{ inputs.limit_severities_for_sarif }}
       env:
         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
         type: string
+      ignore_unfixed:
+        description: 'Asserts the Trivy scan to ignore vulnerabilities that have no current fix'
+        required: false
+        default: true
+        type: boolean
     secrets:
       HMPPS_SRE_SLACK_BOT_TOKEN:
         description: 'Slack bot token'
@@ -43,7 +48,7 @@ jobs:
       with:
         image-ref: "${{ env.repo }}/${{ inputs.subproject == '' && github.event.repository.name || inputs.subproject}}:latest"
         severity: 'HIGH,CRITICAL'
-        ignore-unfixed: false
+        ignore-unfixed: ${{ inputs.ignore_unfixed }}
         skip-dirs: '/usr/local/lib/node_modules/npm'
         skip-files: /app/agent.jar
         format: 'sarif'

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -18,6 +18,16 @@ on:
         required: false
         default: true
         type: boolean
+      severity:
+        description: 'Customisable severity levels'
+        required: false
+        default: 'HIGH,CRITICAL'
+        type: string
+      limit-severities-for-sarif:
+        description: 'only includes severities as defined in the sarif file'
+        required: false
+        default: true
+        type: boolean
     secrets:
       HMPPS_SRE_SLACK_BOT_TOKEN:
         description: 'Slack bot token'
@@ -47,14 +57,14 @@ jobs:
       uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       with:
         image-ref: "${{ env.repo }}/${{ inputs.subproject == '' && github.event.repository.name || inputs.subproject}}:latest"
-        severity: 'HIGH,CRITICAL'
+        severity: ${{ inputs.severity }}
         ignore-unfixed: ${{ inputs.ignore_unfixed }}
         skip-dirs: '/usr/local/lib/node_modules/npm'
         skip-files: /app/agent.jar
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: 1
-        limit-severities-for-sarif: true
+        limit-severities-for-sarif: ${{ inputs.limit-severities-for-sarif }}
       env:
         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1


### PR DESCRIPTION
Currently this is set to ignore_unfixed= 'true' by default - I'll validate with the template repos once this is tagged.