### PR TITLE
Support prod envs named 'production'

### DIFF
--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set Slack Channel ID
         id: set-slack-channel-id
         run: |
-          if [[ "${{ inputs.environment }}" == "prod" ]]; then
+          if [[ "${{ inputs.environment }}" == "prod" || "${{ inputs.environment }}" == "production" ]]; then
             echo "slack_channel_id=${{ vars.PROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT
           else
             echo "slack_channel_id=${{ vars.NONPROD_RELEASES_SLACK_CHANNEL }}" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
Tiny change to support envs named "production" in addition to "prod".