### PR TITLE
add language codeql scan

### DIFF
--- a/.github/workflows/security_codeql.yml
+++ b/.github/workflows/security_codeql.yml
@@ -1,0 +1,55 @@
+name: Security CodeQL check
+
+on:
+  workflow_call:
+    inputs:
+      channel_id:
+        description: 'The slack channel ID to send a message on failure. If this is not provided then no message is sent.'
+        required: false
+        default: 'NO_SLACK'
+        type: string
+      languages:
+        description: 'The languages that the CodeQL scan will check (singular or comma-separated)'
+        required: true
+        type: string
+      build_mode:
+        description: 'Whether the app is built or not before scanning'
+        required: false
+        default: 'none'
+        type: string
+    secrets:
+      HMPPS_SRE_SLACK_BOT_TOKEN:
+        description: 'Slack bot token'
+        required: false
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security-codeql-scan:
+    name: Security CodeQL scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ inputs.languages }}
+        build-mode: ${{ inputs.build_mode }}
+    - name: Perform CodeQL Analysis
+      id: codeql_analysis
+      uses: github/codeql-action/analyze@v3
+    - name: CodeQL slack notification
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_codescan_notification@v2 # WORKFLOW_VERSION
+      if: (failure() || steps.codeql_analysis.outcome == 'failure') && inputs.channel_id != 'NO_SLACK'
+      with:
+        title: "CodeQL ${{ inputs.languages }} check"
+        warningOnly: ${{ steps.codeql_analysis.outcome == 'success' }}
+        channel_id: ${{ inputs.channel_id}}
+        SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
A very basic codeQL scan including inputs for language and build_mode.

Validated with python on my [boostrap-validation](https://github.com/ministryofjustice/hmpps-james-bootstrap/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS643FMN2XE2LUPFPWG33EMVYWYX3QPF2GQ33OL5ZWGYLOFZ4W23A) repo 