### PR TITLE
Support for pre-packaged veracode source code

### DIFF
--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: '/app'
         type: string
+      veracode_package_artifact_name:
+        required: false
+        type: string
+        default: ''
+        description: "The name of the artifact to download, containing a source.zip packaged application. Optional."
     secrets:
       HMPPS_SRE_SLACK_BOT_TOKEN:
         description: Slack bot token
@@ -71,9 +76,15 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - name: prepare assets
+      if: inputs.veracode_package_artifact_name == ''
       uses: ministryofjustice/hmpps-github-actions/.github/actions/security_veracode_prepare_artifacts@v2 # WORKFLOW_VERSION
       with:
         docker_image_app_dir: ${{ inputs.docker_image_app_dir }}
+    - name: download assets artifact
+      if: inputs.veracode_package_artifact_name != ''
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.veracode_package_artifact_name }}
     - name: "Download/Extract pipeline scanner"
       shell: bash
       run: |

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -16,6 +16,11 @@ on:
         type: string
         default: "hmpps-tech"
         description: "Comma-separated list of team names associated with the specified application.  Validates against the names of existing teams for this account."
+      veracode_package_artifact_name:
+        required: false
+        type: string
+        default: ''
+        description: "The name of the artifact to download, containing a source.zip packaged application. Optional."
     secrets:
       HMPPS_SRE_SLACK_BOT_TOKEN:
         description: Slack bot token
@@ -76,9 +81,15 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - name: prepare assets
+      if: inputs.veracode_package_artifact_name == ''
       uses: ministryofjustice/hmpps-github-actions/.github/actions/security_veracode_prepare_artifacts@v2 # WORKFLOW_VERSION
       with:
         docker_image_app_dir: ${{ inputs.docker_image_app_dir }}
+    - name: download assets artifact
+      if: inputs.veracode_package_artifact_name != ''
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.veracode_package_artifact_name }}
     - name: "Download/Extract veracode agent"
       run: wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/22.9.10.3/vosp-api-wrappers-java-22.9.10.3.jar -O VeracodeJavaAPI.jar
     - name: "Upload to Veracode"
@@ -127,4 +138,3 @@ jobs:
         channel_id: ${{ inputs.channel_id }}
         input_file: output.txt
 
-  


### PR DESCRIPTION
This backward compatible change introduces the ability to provide an optional `veracode_package_artifact_name` argument to the veracode scan workflows, allowing applications different to kotlin/typescript, for instance Rails, to package their source code themselves, store it as an artifact, and the veracode workflow will download and use this artifact, instead of using the `security_veracode_prepare_artifacts` action, which is not compatible with some languages like Rails that require a specific packaging process.

### Example workflows

Pipeline scan:
https://github.com/ministryofjustice/hmpps-complexity-of-need/actions/runs/15276369612

Policy scan:
https://github.com/ministryofjustice/hmpps-complexity-of-need/actions/runs/15276369650