### PR TITLE
FEAT/HEAT-767 - self hosted runners for OWASP scans

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: true
         type: boolean
+      nvd_feed_version:
+        description: 'version of the NVD feed to use'
+        required: false
+        default: '1'
+        type: string
     secrets:
       HMPPS_SRE_SLACK_BOT_TOKEN:
         description: 'Slack bot token'
@@ -28,10 +33,66 @@ permissions:
   security-events: write
 
 jobs:
-  security-owasp-check:
+  # NVD v2 API version of the scan - using self-hosted runner
+  security-owasp-check-nvd2:
     name: Security OWASP dependency check
     runs-on:  [ self-hosted, hmpps-github-actions-runner-security ]
-    if: startsWith(github.repository, 'ministryofjustice/')
+    if: startsWith(github.repository, 'ministryofjustice/') && inputs.nvd_feed_version=='2'
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+    - name: Run gradle OWASP Dependency Check Analyse
+      id: owasp-analyse
+      run: ./gradlew ${{ inputs.subproject }}:dependencyCheckAnalyze --info
+      continue-on-error: true
+    # Upload Sarif file: this will attempt to upload the sarif file for private/internal repositories as well
+    - name: OWASP upload sarif
+      id: owasp-upload-sarif
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.subproject == '' && '.' || inputs.subproject }}/build/reports/dependency-check-report.sarif
+        category: gradle-owasp-dependency-check
+      # don't stop the job even if Github Advanced Security isn't enabled
+      continue-on-error: true
+    - uses: actions/upload-artifact@v4
+      id: owasp-upload-artifact
+      with:
+        name: gradle-owasp-dependency-check-${{ inputs.subproject == '' && github.event.repository.name || inputs.subproject }}
+        path: ${{ inputs.subproject == '' && '.' || inputs.subproject }}/build/reports/dependency-check-report.html
+    - name: Prepare OWASP summary
+      id: owasp-summary
+      run: |
+        formatted_output=$(jq -r '.runs[0].tool.driver.rules[] | [.id, .shortDescription.text, .properties.cvssv2_score, .properties.cvssv2_severity] | @tsv' ${{ inputs.subproject == '' && '.' || inputs.subproject }}/build/reports/dependency-check-report.sarif \
+        | awk -F'\t' '{print $1" - "$NF" ("$(NF-1)") - "substr($2,index($2,":")+1)}' \
+        | awk '{printf "%s\\n", $0}') 
+        echo "Vulnerability Summary"
+        echo "====================="
+        echo "${formatted_output}" | sed 's/\\n/\n/g'
+        slack_summary="$(echo "${formatted_output}" | awk '{s=s $0} END {if (length(s) >= 3000) print substr(s, 1, 2997) "..."; else print s}')"
+        echo "summary=${slack_summary}" >> $GITHUB_ENV
+    - name: Gradle OWASP slack notification
+      uses: ministryofjustice/hmpps-github-actions/.github/actions/slack_codescan_notification@v2 # WORKFLOW_VERSION
+      if: (failure() || steps.owasp-analyse.outcome == 'failure') && inputs.channel_id != 'NO_SLACK'
+      with:
+        title: "Gradle OWASP"
+        warningOnly: ${{ steps.owasp-upload-sarif.outcome == 'success' && steps.owasp-upload-artifact.outcome == 'success' }}
+        channel_id: ${{ inputs.channel_id}}
+        SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}
+        subproject: ${{ inputs.subproject }}
+        summary: ${{ inputs.slack_include_summary && env.summary || '' }}
+  # Previous NVD API version - this will no longer be default when the database is no longer available
+  security-owasp-check-nvd1:
+    name: Security OWASP dependency check
+    runs-on:  ubuntu-latest
+    if: inputs.nvd_feed_version=='1'
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   security-owasp-check:
     name: Security OWASP dependency check
-    runs-on: ubuntu-latest
+    runs-on:  [ self-hosted, hmpps-github-actions-runner-security ]
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -31,6 +31,7 @@ jobs:
   security-owasp-check:
     name: Security OWASP dependency check
     runs-on:  [ self-hosted, hmpps-github-actions-runner-security ]
+    if: startsWith(github.repository, 'ministryofjustice/')
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   # NVD v2 API version of the scan - using self-hosted runner
   security-owasp-check-nvd2:
-    name: Security OWASP dependency check
+    name: Security OWASP dependency check (NVD API 2)
     runs-on:  [ self-hosted, hmpps-github-actions-runner-security ]
     if: startsWith(github.repository, 'ministryofjustice/') && inputs.nvd_feed_version=='2'
     permissions:
@@ -90,7 +90,7 @@ jobs:
         summary: ${{ inputs.slack_include_summary && env.summary || '' }}
   # Previous NVD API version - this will no longer be default when the database is no longer available
   security-owasp-check-nvd1:
-    name: Security OWASP dependency check
+    name: Security OWASP dependency check (NVD API 1)
     runs-on:  ubuntu-latest
     if: inputs.nvd_feed_version=='1'
     permissions:

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -37,7 +37,7 @@ jobs:
   security-owasp-check-nvd2:
     name: Security OWASP dependency check (NVD API 2)
     runs-on:  [ self-hosted, hmpps-github-actions-runner-security ]
-    if: startsWith(github.repository, 'ministryofjustice/') && inputs.nvd_feed_version=='2'
+    if: github.repository_owner ==  'ministryofjustice' && inputs.nvd_feed_version=='2'
     permissions:
       security-events: write
       contents: read

--- a/kotlin-to-nvd2.bash
+++ b/kotlin-to-nvd2.bash
@@ -18,7 +18,7 @@ function update_security_owasp_yml() {
   yml_file=".github/workflows/security_owasp.yml"
   if [ $(yq '.jobs."security-kotlin-owasp-check".with.nvd_feed_version' ${yml_file}) != "2" ] ; 
   then 
-    yq e -i '.jobs."security-kotlin-owasp-check".with.nvd_feed_version = 2' ${yml_file}
+    yq e -i '.jobs."security-kotlin-owasp-check".with.nvd_feed_version = "2"' ${yml_file}
     echo "Added nvd_feed_version: 2 to ${yml_file}"
   else
     echo "nvd_feed_version: 2 already in ${yml_file} - no action taken"

--- a/kotlin-to-nvd2.bash
+++ b/kotlin-to-nvd2.bash
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# To be run from inside the github project that you would like to create / update the OWASP security job; expected usage is:
+# ../hmpps-github-actions/kotlin-to-nvd2.bash
+#
+# This will add the appropriate configurations to:
+# - build.gradle.kts
+# - security_owasp.yml
+#
+# If the configuration is already there, it won't add it again
+#
+# Requires yq (v4) to be installed and hmpps-github-actions to be checked out (and up to date) at the same level as this
+# github project. 
+#
+
+
+function update_security_owasp_yml() {
+  yml_file=".github/workflows/security_owasp.yml"
+  if [ $(yq '.jobs."security-kotlin-owasp-check".with.nvd_feed_version' ${yml_file}) != "2" ] ; 
+  then 
+    yq e -i '.jobs."security-kotlin-owasp-check".with.nvd_feed_version = 2' ${yml_file}
+    echo "Added nvd_feed_version: 2 to ${yml_file}"
+  else
+    echo "nvd_feed_version: 2 already in ${yml_file} - no action taken"
+  fi 
+}
+
+function update_build_gradle_kts() {
+  FILE='build.gradle.kts'
+  PLUGIN_LINE='  id("org.owasp.dependencycheck") version "12.1.3"'
+  DEPENDENCY_BLOCK='dependencyCheck {\n  nvd.datafeedUrl = "file:///opt/vulnz/cache"\n}'
+
+  # 1. Check and fix plugin version
+  echo "Checking for dependencyCheck plugin version"
+  
+  awk -v plugin='  id("org.owasp.dependencycheck") version "12.1.3"' '
+  BEGIN {
+    step = 0 
+    found = 0
+  }
+  # change to step 1 when we are at the plugins stage
+  {
+    if ($0 ~ /plugins[[:space:]]*{/) {
+      print
+      step = 1
+      next
+    }
+    if (step==1){
+    # Check for existing plugin line
+      if ($0 ~ /id\(\"org\.owasp\.dependencycheck\"\)/) {
+        found = 1
+        # Replace incorrect version
+        if ($0 !~ /version "12\.1\.3"/) {
+          sub(/version "[^"]+"/, "version \"12.1.3\"")
+        }
+      }
+      if (found==0 && $0 ~ /}/) {
+        step = 2
+        print plugin
+        print
+        next
+      }
+    }
+    print
+  }
+  ' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+
+
+  # 2. Check and add dependencyCheck block
+  echo "Checking for dependencyCheck feed configuration"
+  if ! grep -q 'dependencyCheck {' "$FILE"; then
+    echo "Adding dependencyCheck block..."
+    echo -e "\n$DEPENDENCY_BLOCK" >> "$FILE"
+  else
+    echo "dependencyCheck block already exists - no action taken"
+  fi
+
+}
+
+update_security_owasp_yml
+update_build_gradle_kts


### PR DESCRIPTION
- Extra OWASP job added for when `nvd_feed_version=2` 
- This only runs on ministryofjustice/ repositories

Note: this needs changes to be made to `build.gradle.kts` in the local project directory. To assist with this, I've made a script - kotlin-to-nvd2.bash - that does the appropriate configuration in the local repo.

Currently there are four self-hosted runners (each sharing an API key, but that's only required on build, and they are staggered) - if we need more due to queuing, we can sort that out later.