### PR TITLE
Scope int-test-init to be ci specific

### DIFF
--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - name: Init testing framework if necessary
-        run: npm run int-test-init --if-present
+        run: npm run int-test-init:ci --if-present
       - name: Get wiremock
         shell: bash
         run: |


### PR DESCRIPTION
This matches the established convention, i.e: `npm run test:ci`