### PR TITLE
Add SHA256 checksum verification for binary downloads

### DIFF
--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -70,6 +70,7 @@ runs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
+    - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/setup-kubectl@v2 # WORKFLOW_VERSION
     - name: Authenticate
       uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/cloud-platform-auth@v2 # WORKFLOW_VERSION
       with:

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -23,9 +23,6 @@ inputs:
   token:
     description: The KUBE_TOKEN
     required: true
-  github_token:
-    description: GitHub token for gh API calls
-    required: true
   k8s_deployment_name:
     description: "Kubernetes deployment name, also Helm release name"
     required: true

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -107,22 +107,7 @@ runs:
           echo "ALLOWLIST_VERSION=--set generic-service.allowlist_version=${{ inputs.helm_allowlist_version }}" >> $GITHUB_OUTPUT
         fi
 
-    # Install Helm v4 with checksum verification
-    - name: Install Helm
-      id: install-helm
-      shell: bash
-      env:
-        # renovate: datasource=github-releases depName=helm/helm
-        HELM_VERSION: v4.1.3
-        # SHA256 from https://github.com/helm/helm/releases (linux-amd64)
-        HELM_SHA256: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
-      run: |
-        curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
-        echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
-        tar -xzf helm.tar.gz
-        sudo mv linux-amd64/helm /usr/local/bin/helm
-        rm -rf helm.tar.gz linux-amd64
-        helm version
+    - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/setup-helm@v2 # WORKFLOW_VERSION
 
     - name: Deploy
       shell: bash

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -110,19 +110,22 @@ runs:
           echo "ALLOWLIST_VERSION=--set generic-service.allowlist_version=${{ inputs.helm_allowlist_version }}" >> $GITHUB_OUTPUT
         fi
 
-    - name: Get latest Helm v4 version
+    # Install Helm v4 with checksum verification
+    # renovate: datasource=github-releases depName=helm/helm
+    - name: Install Helm
+      id: install-helm
       shell: bash
-      id: helm-version
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        HELM_VERSION: v4.1.3
+        # SHA256 from https://github.com/helm/helm/releases (linux-amd64)
+        HELM_SHA256: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
       run: |
-        LATEST_V4=$(gh api repos/helm/helm/releases --jq '[.[] | select(.tag_name | startswith("v4.")) | select(.prerelease == false) | .tag_name] | first')
-        echo "version=${LATEST_V4}" >> $GITHUB_OUTPUT
-        echo "Latest Helm v4 version: ${LATEST_V4}"
-
-    - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
-      with:
-        version: ${{ steps.helm-version.outputs.version }}
+        curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+        echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
+        tar -xzf helm.tar.gz
+        sudo mv linux-amd64/helm /usr/local/bin/helm
+        rm -rf helm.tar.gz linux-amd64
+        helm version
 
     - name: Deploy
       shell: bash

--- a/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
+++ b/.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml
@@ -108,11 +108,11 @@ runs:
         fi
 
     # Install Helm v4 with checksum verification
-    # renovate: datasource=github-releases depName=helm/helm
     - name: Install Helm
       id: install-helm
       shell: bash
       env:
+        # renovate: datasource=github-releases depName=helm/helm
         HELM_VERSION: v4.1.3
         # SHA256 from https://github.com/helm/helm/releases (linux-amd64)
         HELM_SHA256: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700

--- a/.github/actions/build-test-and-deploy/setup-helm/action.yml
+++ b/.github/actions/build-test-and-deploy/setup-helm/action.yml
@@ -1,0 +1,21 @@
+name: Setup Helm
+description: Install Helm with checksum verification
+
+runs:
+  using: composite
+  steps:
+    - name: Install Helm
+      id: install-helm
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=helm/helm
+        HELM_VERSION: v4.1.3
+        # SHA256 from https://github.com/helm/helm/releases (linux-amd64)
+        HELM_SHA256: 02ce9722d541238f81459938b84cf47df2fdf1187493b4bfb2346754d82a4700
+      run: |
+        curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+        echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
+        tar -xzf helm.tar.gz
+        sudo mv linux-amd64/helm /usr/local/bin/helm
+        rm -rf helm.tar.gz linux-amd64
+        helm version

--- a/.github/actions/build-test-and-deploy/setup-kubectl/action.yml
+++ b/.github/actions/build-test-and-deploy/setup-kubectl/action.yml
@@ -1,0 +1,20 @@
+name: Setup kubectl
+description: Install kubectl with checksum verification
+
+runs:
+  using: composite
+  steps:
+    - name: Install kubectl
+      id: install-kubectl
+      shell: bash
+      env:
+        # renovate: datasource=github-releases depName=kubernetes/kubernetes
+        KUBECTL_VERSION: v1.33.10
+        # SHA256 from https://dl.k8s.io/release/${VERSION}/bin/linux/amd64/kubectl.sha256
+        KUBECTL_SHA256: f156acb753ee4366789ab7a663916eb580e7ee1b9e449bc9b052181db524e3f5
+      run: |
+        curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
+        echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c -
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/kubectl
+        kubectl version --client

--- a/.github/actions/database_schema_report/action.yml
+++ b/.github/actions/database_schema_report/action.yml
@@ -47,23 +47,15 @@ runs:
         java-version: ${{ inputs.jdk_tag }}
         distribution: 'temurin'
 
-    - name: Install schemaspy
-      shell: bash
-      env:
-        SCHEMASPY_VERSION: ${{ inputs.schemaspy_version }}
-        SCHEMASPY_SHA256: ${{ inputs.schemaspy_sha256 }}
-      run: |
-        curl -fsSL "https://github.com/schemaspy/schemaspy/releases/download/v${SCHEMASPY_VERSION}/schemaspy-${SCHEMASPY_VERSION}.jar" -o /tmp/schemaspy.jar
-        echo "${SCHEMASPY_SHA256}  /tmp/schemaspy.jar" | sha256sum -c -
+    - uses: ministryofjustice/hmpps-github-actions/.github/actions/setup-schemaspy@v2 # WORKFLOW_VERSION
+      with:
+        version: ${{ inputs.schemaspy_version }}
+        sha256: ${{ inputs.schemaspy_sha256 }}
 
-    - name: Install postgres jdbc driver
-      shell: bash
-      env:
-        POSTGRES_DRIVER_VERSION: ${{ inputs.postgres_driver_version }}
-        POSTGRES_DRIVER_SHA256: ${{ inputs.postgres_driver_sha256 }}
-      run: |
-        curl -fsSL "https://jdbc.postgresql.org/download/postgresql-${POSTGRES_DRIVER_VERSION}.jar" -o /tmp/postgres-driver.jar
-        echo "${POSTGRES_DRIVER_SHA256}  /tmp/postgres-driver.jar" | sha256sum -c -
+    - uses: ministryofjustice/hmpps-github-actions/.github/actions/setup-postgres-jdbc@v2 # WORKFLOW_VERSION
+      with:
+        version: ${{ inputs.postgres_driver_version }}
+        sha256: ${{ inputs.postgres_driver_sha256 }}
 
     - name: Generate database schema report
       shell: bash

--- a/.github/actions/database_schema_report/action.yml
+++ b/.github/actions/database_schema_report/action.yml
@@ -23,12 +23,20 @@ inputs:
   password:
     default: "dev"
     description: Database password
+  # renovate: datasource=github-releases depName=schemaspy/schemaspy
   schemaspy_version:
     default: "6.2.4"
     description: Schemaspy version
+  schemaspy_sha256:
+    default: "50abf42c6fbf746b36365f81adb9686e1da83344e89f2719a31e6c1209ebcaad"
+    description: SHA256 checksum for SchemaSpy JAR (from GitHub releases)
+  # renovate: datasource=maven depName=org.postgresql:postgresql
   postgres_driver_version:
     default: "42.7.3"
     description: Postgres driver version
+  postgres_driver_sha256:
+    default: "a2644cbfba1baa145ff7e8c8ef582a6eed7a7ec4ca792f7f054122bdec756268"
+    description: SHA256 checksum for PostgreSQL JDBC driver
 
 runs:
   using: "composite"
@@ -41,11 +49,21 @@ runs:
 
     - name: Install schemaspy
       shell: bash
-      run: curl -L https://github.com/schemaspy/schemaspy/releases/download/v${{ inputs.schemaspy_version }}/schemaspy-${{ inputs.schemaspy_version }}.jar --output /tmp/schemaspy.jar
+      env:
+        SCHEMASPY_VERSION: ${{ inputs.schemaspy_version }}
+        SCHEMASPY_SHA256: ${{ inputs.schemaspy_sha256 }}
+      run: |
+        curl -fsSL "https://github.com/schemaspy/schemaspy/releases/download/v${SCHEMASPY_VERSION}/schemaspy-${SCHEMASPY_VERSION}.jar" -o /tmp/schemaspy.jar
+        echo "${SCHEMASPY_SHA256}  /tmp/schemaspy.jar" | sha256sum -c -
 
     - name: Install postgres jdbc driver
       shell: bash
-      run: curl -L https://jdbc.postgresql.org/download/postgresql-${{ inputs.postgres_driver_version }}.jar --output /tmp/postgres-driver.jar
+      env:
+        POSTGRES_DRIVER_VERSION: ${{ inputs.postgres_driver_version }}
+        POSTGRES_DRIVER_SHA256: ${{ inputs.postgres_driver_sha256 }}
+      run: |
+        curl -fsSL "https://jdbc.postgresql.org/download/postgresql-${POSTGRES_DRIVER_VERSION}.jar" -o /tmp/postgres-driver.jar
+        echo "${POSTGRES_DRIVER_SHA256}  /tmp/postgres-driver.jar" | sha256sum -c -
 
     - name: Generate database schema report
       shell: bash

--- a/.github/actions/database_schema_report/action.yml
+++ b/.github/actions/database_schema_report/action.yml
@@ -23,15 +23,15 @@ inputs:
   password:
     default: "dev"
     description: Database password
-  # renovate: datasource=github-releases depName=schemaspy/schemaspy
   schemaspy_version:
+    # renovate: datasource=github-releases depName=schemaspy/schemaspy
     default: "6.2.4"
     description: Schemaspy version
   schemaspy_sha256:
     default: "50abf42c6fbf746b36365f81adb9686e1da83344e89f2719a31e6c1209ebcaad"
     description: SHA256 checksum for SchemaSpy JAR (from GitHub releases)
-  # renovate: datasource=maven depName=org.postgresql:postgresql
   postgres_driver_version:
+    # renovate: datasource=maven depName=org.postgresql:postgresql
     default: "42.7.3"
     description: Postgres driver version
   postgres_driver_sha256:

--- a/.github/actions/setup-postgres-jdbc/action.yml
+++ b/.github/actions/setup-postgres-jdbc/action.yml
@@ -1,0 +1,32 @@
+name: Setup PostgreSQL JDBC
+description: Download PostgreSQL JDBC driver with checksum verification
+
+inputs:
+  version:
+    description: PostgreSQL JDBC driver version
+    required: false
+    # renovate: datasource=maven depName=org.postgresql:postgresql
+    default: "42.7.3"
+  sha256:
+    description: SHA256 checksum for PostgreSQL JDBC driver
+    required: false
+    default: "a2644cbfba1baa145ff7e8c8ef582a6eed7a7ec4ca792f7f054122bdec756268"
+
+outputs:
+  jar_path:
+    description: Path to the PostgreSQL JDBC driver JAR file
+    value: ${{ steps.download-postgres-jdbc.outputs.jar_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download PostgreSQL JDBC driver
+      id: download-postgres-jdbc
+      shell: bash
+      env:
+        POSTGRES_DRIVER_VERSION: ${{ inputs.version }}
+        POSTGRES_DRIVER_SHA256: ${{ inputs.sha256 }}
+      run: |
+        curl -fsSL "https://jdbc.postgresql.org/download/postgresql-${POSTGRES_DRIVER_VERSION}.jar" -o /tmp/postgres-driver.jar
+        echo "${POSTGRES_DRIVER_SHA256}  /tmp/postgres-driver.jar" | sha256sum -c -
+        echo "jar_path=/tmp/postgres-driver.jar" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-schemaspy/action.yml
+++ b/.github/actions/setup-schemaspy/action.yml
@@ -1,0 +1,32 @@
+name: Setup SchemaSpy
+description: Download SchemaSpy JAR with checksum verification
+
+inputs:
+  version:
+    description: SchemaSpy version
+    required: false
+    # renovate: datasource=github-releases depName=schemaspy/schemaspy
+    default: "6.2.4"
+  sha256:
+    description: SHA256 checksum for SchemaSpy JAR
+    required: false
+    default: "50abf42c6fbf746b36365f81adb9686e1da83344e89f2719a31e6c1209ebcaad"
+
+outputs:
+  jar_path:
+    description: Path to the SchemaSpy JAR file
+    value: ${{ steps.download-schemaspy.outputs.jar_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download SchemaSpy
+      id: download-schemaspy
+      shell: bash
+      env:
+        SCHEMASPY_VERSION: ${{ inputs.version }}
+        SCHEMASPY_SHA256: ${{ inputs.sha256 }}
+      run: |
+        curl -fsSL "https://github.com/schemaspy/schemaspy/releases/download/v${SCHEMASPY_VERSION}/schemaspy-${SCHEMASPY_VERSION}.jar" -o /tmp/schemaspy.jar
+        echo "${SCHEMASPY_SHA256}  /tmp/schemaspy.jar" | sha256sum -c -
+        echo "jar_path=/tmp/schemaspy.jar" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-veracode-wrapper/action.yml
+++ b/.github/actions/setup-veracode-wrapper/action.yml
@@ -1,0 +1,23 @@
+name: Setup Veracode Wrapper
+description: Download Veracode Java API wrapper with checksum verification
+
+outputs:
+  jar_path:
+    description: Path to the Veracode wrapper JAR file
+    value: ${{ steps.download-veracode-wrapper.outputs.jar_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download Veracode wrapper
+      id: download-veracode-wrapper
+      shell: bash
+      env:
+        # renovate: datasource=maven depName=com.veracode.vosp.api.wrappers:vosp-api-wrappers-java
+        VERACODE_WRAPPER_VERSION: 26.3.19.0
+        # SHA256 checksum for verification
+        VERACODE_WRAPPER_SHA256: 56d9f6d812261f1e3b69ead4d0b7ac6be7c817bd9aef432ea3a74edc8abf8b6f
+      run: |
+        curl -fsSL "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar" -o VeracodeJavaAPI.jar
+        echo "${VERACODE_WRAPPER_SHA256}  VeracodeJavaAPI.jar" | sha256sum -c -
+        echo "jar_path=$(pwd)/VeracodeJavaAPI.jar" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-wiremock/action.yml
+++ b/.github/actions/setup-wiremock/action.yml
@@ -1,0 +1,23 @@
+name: Setup WireMock
+description: Download WireMock standalone JAR with checksum verification
+
+outputs:
+  jar_path:
+    description: Path to the WireMock JAR file
+    value: ${{ steps.download-wiremock.outputs.jar_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download WireMock
+      id: download-wiremock
+      shell: bash
+      env:
+        # renovate: datasource=maven depName=org.wiremock:wiremock-standalone
+        WIREMOCK_VERSION: 3.9.1
+        # SHA256 from Maven Central
+        WIREMOCK_SHA256: 723a880d50d3b0a145af0df07e578c2cb85e77feb2231e6991c9a1366926912c
+      run: |
+        curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
+        echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
+        echo "jar_path=$(pwd)/wiremock.jar" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -101,7 +101,6 @@ jobs:
           cluster: ${{ secrets.KUBE_CLUSTER }}
           namespace: ${{ secrets.KUBE_NAMESPACE }}
           token: ${{ secrets.KUBE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           k8s_deployment_name: ${{ inputs.k8s_deployment_name }}
           changelog_git_paths: ${{ inputs.changelog_git_paths }}
           show_changelog: ${{ inputs.show_changelog }}

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -77,10 +77,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
-        id: install
-        with:
-          version: latest
 
       - name: Set Slack Channel ID
         id: set-slack-channel-id

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -67,17 +67,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: Init testing framework if necessary
         run: npm run int-test-init:ci --if-present
-      - name: Get wiremock
-        id: get-wiremock
-        shell: bash
-        env:
-          # renovate: datasource=maven depName=org.wiremock:wiremock-standalone
-          WIREMOCK_VERSION: 3.9.1
-          # SHA256 from Maven Central
-          WIREMOCK_SHA256: 723a880d50d3b0a145af0df07e578c2cb85e77feb2231e6991c9a1366926912c
-        run: |
-          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
-          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/setup-wiremock@v2 # WORKFLOW_VERSION
       - name: Prepare and run integration tests
         id: integration-tests
         shell: bash

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -68,9 +68,16 @@ jobs:
       - name: Init testing framework if necessary
         run: npm run int-test-init:ci --if-present
       - name: Get wiremock
+        id: get-wiremock
         shell: bash
+        env:
+          # renovate: datasource=maven depName=org.wiremock:wiremock-standalone
+          WIREMOCK_VERSION: 3.9.1
+          # SHA256 from Maven Central
+          WIREMOCK_SHA256: 723a880d50d3b0a145af0df07e578c2cb85e77feb2231e6991c9a1366926912c
         run: |
-          curl -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
+          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
       - name: Prepare and run integration tests
         id: integration-tests
         shell: bash

--- a/.github/workflows/node_integration_tests_redis.yml
+++ b/.github/workflows/node_integration_tests_redis.yml
@@ -44,9 +44,16 @@ jobs:
             ~/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: Get wiremock
+        id: get-wiremock
         shell: bash
+        env:
+          # renovate: datasource=maven depName=org.wiremock:wiremock-standalone
+          WIREMOCK_VERSION: 3.9.1
+          # SHA256 from Maven Central
+          WIREMOCK_SHA256: 723a880d50d3b0a145af0df07e578c2cb85e77feb2231e6991c9a1366926912c
         run: |
-          curl -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
+          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
       - name: Prepare and run integration tests
         id: integration-tests
         shell: bash

--- a/.github/workflows/node_integration_tests_redis.yml
+++ b/.github/workflows/node_integration_tests_redis.yml
@@ -43,17 +43,7 @@ jobs:
             ./node_modules
             ~/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
-      - name: Get wiremock
-        id: get-wiremock
-        shell: bash
-        env:
-          # renovate: datasource=maven depName=org.wiremock:wiremock-standalone
-          WIREMOCK_VERSION: 3.9.1
-          # SHA256 from Maven Central
-          WIREMOCK_SHA256: 723a880d50d3b0a145af0df07e578c2cb85e77feb2231e6991c9a1366926912c
-        run: |
-          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
-          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
+      - uses: ministryofjustice/hmpps-github-actions/.github/actions/setup-wiremock@v2 # WORKFLOW_VERSION
       - name: Prepare and run integration tests
         id: integration-tests
         shell: bash

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -94,6 +94,8 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ inputs.veracode_package_artifact_name }}
+    # Note: Veracode only publishes LATEST - no versioned downloads available.
+    # See https://docs.veracode.com/r/Pipeline_Scan
     - name: "Download/Extract pipeline scanner"
       shell: bash
       run: |

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -105,7 +105,16 @@ jobs:
       with:
         name: ${{ inputs.veracode_package_artifact_name }}
     - name: "Download/Extract veracode agent"
-      run: wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/22.9.10.3/vosp-api-wrappers-java-22.9.10.3.jar -O VeracodeJavaAPI.jar
+      id: download-veracode-agent
+      shell: bash
+      env:
+        # renovate: datasource=maven depName=com.veracode.vosp.api.wrappers:vosp-api-wrappers-java
+        VERACODE_WRAPPER_VERSION: 26.3.19.0
+        # SHA256 checksum for verification
+        VERACODE_WRAPPER_SHA256: 56d9f6d812261f1e3b69ead4d0b7ac6be7c817bd9aef432ea3a74edc8abf8b6f
+      run: |
+        curl -fsSL "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar" -o VeracodeJavaAPI.jar
+        echo "${VERACODE_WRAPPER_SHA256}  VeracodeJavaAPI.jar" | sha256sum -c -
     - name: "Upload to Veracode"
       shell: bash
       run: |

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -104,17 +104,7 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ inputs.veracode_package_artifact_name }}
-    - name: "Download/Extract veracode agent"
-      id: download-veracode-agent
-      shell: bash
-      env:
-        # renovate: datasource=maven depName=com.veracode.vosp.api.wrappers:vosp-api-wrappers-java
-        VERACODE_WRAPPER_VERSION: 26.3.19.0
-        # SHA256 checksum for verification
-        VERACODE_WRAPPER_SHA256: 56d9f6d812261f1e3b69ead4d0b7ac6be7c817bd9aef432ea3a74edc8abf8b6f
-      run: |
-        curl -fsSL "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar" -o VeracodeJavaAPI.jar
-        echo "${VERACODE_WRAPPER_SHA256}  VeracodeJavaAPI.jar" | sha256sum -c -
+    - uses: ministryofjustice/hmpps-github-actions/.github/actions/setup-veracode-wrapper@v2 # WORKFLOW_VERSION
     - name: "Upload to Veracode"
       shell: bash
       run: |

--- a/.github/workflows/test_binary_checksums.yml
+++ b/.github/workflows/test_binary_checksums.yml
@@ -38,7 +38,7 @@ jobs:
           echo "${VERACODE_WRAPPER_SHA256}  VeracodeJavaAPI.jar" | sha256sum -c -
           echo "✅ Veracode wrapper checksum verified"
 
-      - name: Test WireMock checksum
+      - name: Test WireMock checksum (node_integration_tests)
         run: |
           WIREMOCK_VERSION=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_VERSION' .github/workflows/node_integration_tests.yml)
           WIREMOCK_SHA256=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_SHA256' .github/workflows/node_integration_tests.yml)
@@ -46,7 +46,17 @@ jobs:
           echo "Testing WireMock ${WIREMOCK_VERSION}..."
           curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
           echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
-          echo "✅ WireMock checksum verified"
+          echo "✅ WireMock checksum verified (node_integration_tests)"
+
+      - name: Test WireMock checksum (node_integration_tests_redis)
+        run: |
+          WIREMOCK_VERSION=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_VERSION' .github/workflows/node_integration_tests_redis.yml)
+          WIREMOCK_SHA256=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_SHA256' .github/workflows/node_integration_tests_redis.yml)
+          
+          echo "Testing WireMock ${WIREMOCK_VERSION}..."
+          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
+          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
+          echo "✅ WireMock checksum verified (node_integration_tests_redis)"
 
       - name: Test SchemaSpy checksum
         run: |

--- a/.github/workflows/test_binary_checksums.yml
+++ b/.github/workflows/test_binary_checksums.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/node_integration_tests.yml'
       - '.github/workflows/node_integration_tests_redis.yml'
       - '.github/workflows/security_veracode_policy_scan.yml'
-      - '.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml'
+      - '.github/actions/build-test-and-deploy/setup-helm/action.yml'
       - '.github/actions/database_schema_report/action.yml'
       - '.github/workflows/test_binary_checksums.yml'
   workflow_dispatch:
@@ -20,8 +20,8 @@ jobs:
 
       - name: Test Helm checksum
         run: |
-          HELM_VERSION=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_VERSION' .github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml)
-          HELM_SHA256=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_SHA256' .github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml)
+          HELM_VERSION=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_VERSION' .github/actions/build-test-and-deploy/setup-helm/action.yml)
+          HELM_SHA256=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_SHA256' .github/actions/build-test-and-deploy/setup-helm/action.yml)
           
           echo "Testing Helm ${HELM_VERSION}..."
           curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz

--- a/.github/workflows/test_binary_checksums.yml
+++ b/.github/workflows/test_binary_checksums.yml
@@ -1,0 +1,69 @@
+name: Test binary checksums
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/node_integration_tests.yml'
+      - '.github/workflows/node_integration_tests_redis.yml'
+      - '.github/workflows/security_veracode_policy_scan.yml'
+      - '.github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml'
+      - '.github/actions/database_schema_report/action.yml'
+      - '.github/workflows/test_binary_checksums.yml'
+  workflow_dispatch:
+
+jobs:
+  test-checksums:
+    name: Verify binary checksums
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Test Helm checksum
+        run: |
+          HELM_VERSION=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_VERSION' .github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml)
+          HELM_SHA256=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_SHA256' .github/actions/build-test-and-deploy/cloud-platform-deploy/action.yml)
+          
+          echo "Testing Helm ${HELM_VERSION}..."
+          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+          echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
+          echo "✅ Helm checksum verified"
+
+      - name: Test Veracode wrapper checksum
+        run: |
+          VERACODE_WRAPPER_VERSION=$(yq '.jobs.*.steps[] | select(.id == "download-veracode-agent") | .env.VERACODE_WRAPPER_VERSION' .github/workflows/security_veracode_policy_scan.yml)
+          VERACODE_WRAPPER_SHA256=$(yq '.jobs.*.steps[] | select(.id == "download-veracode-agent") | .env.VERACODE_WRAPPER_SHA256' .github/workflows/security_veracode_policy_scan.yml)
+          
+          echo "Testing Veracode wrapper ${VERACODE_WRAPPER_VERSION}..."
+          curl -fsSL "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar" -o VeracodeJavaAPI.jar
+          echo "${VERACODE_WRAPPER_SHA256}  VeracodeJavaAPI.jar" | sha256sum -c -
+          echo "✅ Veracode wrapper checksum verified"
+
+      - name: Test WireMock checksum
+        run: |
+          WIREMOCK_VERSION=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_VERSION' .github/workflows/node_integration_tests.yml)
+          WIREMOCK_SHA256=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_SHA256' .github/workflows/node_integration_tests.yml)
+          
+          echo "Testing WireMock ${WIREMOCK_VERSION}..."
+          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
+          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
+          echo "✅ WireMock checksum verified"
+
+      - name: Test SchemaSpy checksum
+        run: |
+          SCHEMASPY_VERSION=$(yq '.inputs.schemaspy_version.default' .github/actions/database_schema_report/action.yml)
+          SCHEMASPY_SHA256=$(yq '.inputs.schemaspy_sha256.default' .github/actions/database_schema_report/action.yml)
+          
+          echo "Testing SchemaSpy ${SCHEMASPY_VERSION}..."
+          curl -fsSL "https://github.com/schemaspy/schemaspy/releases/download/v${SCHEMASPY_VERSION}/schemaspy-${SCHEMASPY_VERSION}.jar" -o schemaspy.jar
+          echo "${SCHEMASPY_SHA256}  schemaspy.jar" | sha256sum -c -
+          echo "✅ SchemaSpy checksum verified"
+
+      - name: Test PostgreSQL JDBC driver checksum
+        run: |
+          POSTGRES_DRIVER_VERSION=$(yq '.inputs.postgres_driver_version.default' .github/actions/database_schema_report/action.yml)
+          POSTGRES_DRIVER_SHA256=$(yq '.inputs.postgres_driver_sha256.default' .github/actions/database_schema_report/action.yml)
+          
+          echo "Testing PostgreSQL JDBC ${POSTGRES_DRIVER_VERSION}..."
+          curl -fsSL "https://jdbc.postgresql.org/download/postgresql-${POSTGRES_DRIVER_VERSION}.jar" -o postgres-driver.jar
+          echo "${POSTGRES_DRIVER_SHA256}  postgres-driver.jar" | sha256sum -c -
+          echo "✅ PostgreSQL JDBC driver checksum verified"

--- a/.github/workflows/test_binary_checksums.yml
+++ b/.github/workflows/test_binary_checksums.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/test_binary_checksums.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-helm:
     name: Test Helm checksum

--- a/.github/workflows/test_binary_checksums.yml
+++ b/.github/workflows/test_binary_checksums.yml
@@ -3,88 +3,54 @@ name: Test binary checksums
 on:
   pull_request:
     paths:
-      - '.github/workflows/node_integration_tests.yml'
-      - '.github/workflows/node_integration_tests_redis.yml'
-      - '.github/workflows/security_veracode_policy_scan.yml'
       - '.github/actions/build-test-and-deploy/setup-helm/action.yml'
       - '.github/actions/build-test-and-deploy/setup-kubectl/action.yml'
-      - '.github/actions/database_schema_report/action.yml'
+      - '.github/actions/setup-wiremock/action.yml'
+      - '.github/actions/setup-veracode-wrapper/action.yml'
+      - '.github/actions/setup-schemaspy/action.yml'
+      - '.github/actions/setup-postgres-jdbc/action.yml'
       - '.github/workflows/test_binary_checksums.yml'
   workflow_dispatch:
 
 jobs:
-  test-checksums:
-    name: Verify binary checksums
+  test-helm:
+    name: Test Helm checksum
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/build-test-and-deploy/setup-helm
 
-      - name: Test Helm checksum
-        run: |
-          HELM_VERSION=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_VERSION' .github/actions/build-test-and-deploy/setup-helm/action.yml)
-          HELM_SHA256=$(yq '.runs.steps[] | select(.id == "install-helm") | .env.HELM_SHA256' .github/actions/build-test-and-deploy/setup-helm/action.yml)
-          
-          echo "Testing Helm ${HELM_VERSION}..."
-          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
-          echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
-          echo "✅ Helm checksum verified"
+  test-kubectl:
+    name: Test kubectl checksum
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/build-test-and-deploy/setup-kubectl
 
-      - name: Test kubectl checksum
-        run: |
-          KUBECTL_VERSION=$(yq '.runs.steps[] | select(.id == "install-kubectl") | .env.KUBECTL_VERSION' .github/actions/build-test-and-deploy/setup-kubectl/action.yml)
-          KUBECTL_SHA256=$(yq '.runs.steps[] | select(.id == "install-kubectl") | .env.KUBECTL_SHA256' .github/actions/build-test-and-deploy/setup-kubectl/action.yml)
-          
-          echo "Testing kubectl ${KUBECTL_VERSION}..."
-          curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
-          echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c -
-          echo "✅ kubectl checksum verified"
+  test-wiremock:
+    name: Test WireMock checksum
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-wiremock
 
-      - name: Test Veracode wrapper checksum
-        run: |
-          VERACODE_WRAPPER_VERSION=$(yq '.jobs.*.steps[] | select(.id == "download-veracode-agent") | .env.VERACODE_WRAPPER_VERSION' .github/workflows/security_veracode_policy_scan.yml)
-          VERACODE_WRAPPER_SHA256=$(yq '.jobs.*.steps[] | select(.id == "download-veracode-agent") | .env.VERACODE_WRAPPER_SHA256' .github/workflows/security_veracode_policy_scan.yml)
-          
-          echo "Testing Veracode wrapper ${VERACODE_WRAPPER_VERSION}..."
-          curl -fsSL "https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar" -o VeracodeJavaAPI.jar
-          echo "${VERACODE_WRAPPER_SHA256}  VeracodeJavaAPI.jar" | sha256sum -c -
-          echo "✅ Veracode wrapper checksum verified"
+  test-veracode-wrapper:
+    name: Test Veracode wrapper checksum
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-veracode-wrapper
 
-      - name: Test WireMock checksum (node_integration_tests)
-        run: |
-          WIREMOCK_VERSION=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_VERSION' .github/workflows/node_integration_tests.yml)
-          WIREMOCK_SHA256=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_SHA256' .github/workflows/node_integration_tests.yml)
-          
-          echo "Testing WireMock ${WIREMOCK_VERSION}..."
-          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
-          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
-          echo "✅ WireMock checksum verified (node_integration_tests)"
+  test-schemaspy:
+    name: Test SchemaSpy checksum
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-schemaspy
 
-      - name: Test WireMock checksum (node_integration_tests_redis)
-        run: |
-          WIREMOCK_VERSION=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_VERSION' .github/workflows/node_integration_tests_redis.yml)
-          WIREMOCK_SHA256=$(yq '.jobs.*.steps[] | select(.id == "get-wiremock") | .env.WIREMOCK_SHA256' .github/workflows/node_integration_tests_redis.yml)
-          
-          echo "Testing WireMock ${WIREMOCK_VERSION}..."
-          curl -fsSL "https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/${WIREMOCK_VERSION}/wiremock-standalone-${WIREMOCK_VERSION}.jar" -o wiremock.jar
-          echo "${WIREMOCK_SHA256}  wiremock.jar" | sha256sum -c -
-          echo "✅ WireMock checksum verified (node_integration_tests_redis)"
-
-      - name: Test SchemaSpy checksum
-        run: |
-          SCHEMASPY_VERSION=$(yq '.inputs.schemaspy_version.default' .github/actions/database_schema_report/action.yml)
-          SCHEMASPY_SHA256=$(yq '.inputs.schemaspy_sha256.default' .github/actions/database_schema_report/action.yml)
-          
-          echo "Testing SchemaSpy ${SCHEMASPY_VERSION}..."
-          curl -fsSL "https://github.com/schemaspy/schemaspy/releases/download/v${SCHEMASPY_VERSION}/schemaspy-${SCHEMASPY_VERSION}.jar" -o schemaspy.jar
-          echo "${SCHEMASPY_SHA256}  schemaspy.jar" | sha256sum -c -
-          echo "✅ SchemaSpy checksum verified"
-
-      - name: Test PostgreSQL JDBC driver checksum
-        run: |
-          POSTGRES_DRIVER_VERSION=$(yq '.inputs.postgres_driver_version.default' .github/actions/database_schema_report/action.yml)
-          POSTGRES_DRIVER_SHA256=$(yq '.inputs.postgres_driver_sha256.default' .github/actions/database_schema_report/action.yml)
-          
-          echo "Testing PostgreSQL JDBC ${POSTGRES_DRIVER_VERSION}..."
-          curl -fsSL "https://jdbc.postgresql.org/download/postgresql-${POSTGRES_DRIVER_VERSION}.jar" -o postgres-driver.jar
-          echo "${POSTGRES_DRIVER_SHA256}  postgres-driver.jar" | sha256sum -c -
-          echo "✅ PostgreSQL JDBC driver checksum verified"
+  test-postgres-jdbc:
+    name: Test PostgreSQL JDBC checksum
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-postgres-jdbc

--- a/.github/workflows/test_binary_checksums.yml
+++ b/.github/workflows/test_binary_checksums.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/node_integration_tests_redis.yml'
       - '.github/workflows/security_veracode_policy_scan.yml'
       - '.github/actions/build-test-and-deploy/setup-helm/action.yml'
+      - '.github/actions/build-test-and-deploy/setup-kubectl/action.yml'
       - '.github/actions/database_schema_report/action.yml'
       - '.github/workflows/test_binary_checksums.yml'
   workflow_dispatch:
@@ -27,6 +28,16 @@ jobs:
           curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
           echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
           echo "✅ Helm checksum verified"
+
+      - name: Test kubectl checksum
+        run: |
+          KUBECTL_VERSION=$(yq '.runs.steps[] | select(.id == "install-kubectl") | .env.KUBECTL_VERSION' .github/actions/build-test-and-deploy/setup-kubectl/action.yml)
+          KUBECTL_SHA256=$(yq '.runs.steps[] | select(.id == "install-kubectl") | .env.KUBECTL_SHA256' .github/actions/build-test-and-deploy/setup-kubectl/action.yml)
+          
+          echo "Testing kubectl ${KUBECTL_VERSION}..."
+          curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o kubectl
+          echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c -
+          echo "✅ kubectl checksum verified"
 
       - name: Test Veracode wrapper checksum
         run: |

--- a/.github/workflows/test_helm_lint.yml
+++ b/.github/workflows/test_helm_lint.yml
@@ -22,10 +22,6 @@ on:
         required: false
         default: ''
         type: string
-      helm_version:
-        required: false
-        default: 'v3.4.2'
-        type: string
     secrets:
       HMPPS_SRE_SLACK_BOT_TOKEN:
         description: 'Slack bot token'
@@ -40,10 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
-      with:
-        version: ${{ inputs.helm_version }} 
-      id: install_helm
+    - uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/setup-helm@v2 # WORKFLOW_VERSION
     - name: 'Run helm lint commands'
       shell: bash
       run: | 

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,18 @@
 {
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:biweekly"
   ],
   "labels": [
     "dependencies",
     "github-actions"
   ],
   "packageRules": [
+    {
+      "matchManagers": ["github-actions", "custom.regex"],
+      "groupName": "all dependencies",
+      "groupSlug": "all-dependencies"
+    },
     {
       "matchManagers": ["github-actions"],
       "matchFileNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "labels": [
     "dependencies",
@@ -18,40 +18,40 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "excludePackagePrefixes": ["ministryofjustice/hmpps-github-actions"],
+      "matchPackageNames": ["!ministryofjustice/hmpps-github-actions{/,}**"],
       "pinDigests": true
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/(workflows|actions)/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\s+.*_VERSION:\\s*(?<currentValue>v?[\\d.]+)"
+        "# renovate: datasource=github-releases depName=(?<depName>.+?)\\s+[A-Z_]+_VERSION:\\s*(?<currentValue>v?[\\d.]+)"
       ],
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/(workflows|actions)/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\s+\\w+:\\s+default:\\s*\"?(?<currentValue>[\\d.]+)\"?"
+        "# renovate: datasource=github-releases depName=(?<depName>.+?)\\s+default:\\s*[\"']?(?<currentValue>[\\d.]+)[\"']?"
       ],
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/(workflows|actions)/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=maven depName=(?<depName>[^\\s]+)\\s+.*_VERSION:\\s*(?<currentValue>[\\d.]+)"
+        "# renovate: datasource=maven depName=(?<depName>.+?)\\s+[A-Z_]+_VERSION:\\s*(?<currentValue>[\\d.]+)"
       ],
       "datasourceTemplate": "maven"
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/(workflows|actions)/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=maven depName=(?<depName>[^\\s]+)\\s+\\w+:\\s+default:\\s*\"?(?<currentValue>[\\d.]+)\"?"
+        "# renovate: datasource=maven depName=(?<depName>.+?)\\s+default:\\s*[\"']?(?<currentValue>[\\d.]+)[\"']?"
       ],
       "datasourceTemplate": "maven"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -21,5 +21,39 @@
       "excludePackagePrefixes": ["ministryofjustice/hmpps-github-actions"],
       "pinDigests": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\s+.*_VERSION:\\s*(?<currentValue>v?[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\s+\\w+:\\s+default:\\s*\"?(?<currentValue>[\\d.]+)\"?"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=maven depName=(?<depName>[^\\s]+)\\s+.*_VERSION:\\s*(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/(workflows|actions)/.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=maven depName=(?<depName>[^\\s]+)\\s+\\w+:\\s+default:\\s*\"?(?<currentValue>[\\d.]+)\"?"
+      ],
+      "datasourceTemplate": "maven"
+    }
   ]
 }


### PR DESCRIPTION
Protect against supply chain attacks by verifying checksums on all
binary downloads. Extract binary installations into reusable actions
for consistency and testability.

New setup actions:
- setup-helm: Helm CLI with checksum verification
- setup-kubectl: kubectl CLI (replaces azure/setup-kubectl)
- setup-wiremock: WireMock standalone JAR
- setup-veracode-wrapper: Veracode Java API wrapper
- setup-schemaspy: SchemaSpy JAR
- setup-postgres-jdbc: PostgreSQL JDBC driver

Workflow changes:
- cloud-platform-deploy: Uses setup-helm and setup-kubectl
- test_helm_lint: Uses setup-helm (removes helm_version input)
- node_integration_tests: Uses setup-wiremock
- node_integration_tests_redis: Uses setup-wiremock
- security_veracode_policy_scan: Uses setup-veracode-wrapper
- database_schema_report: Uses setup-schemaspy and setup-postgres-jdbc
- deploy_env: Removes azure/setup-kubectl dependency

Add test_binary_checksums.yml workflow:
- Runs setup actions directly to validate checksums on PR
- Fails if checksum doesn't match downloaded binary

Other changes:
- Remove unused github_token input from cloud-platform-deploy
- Update renovate.json with custom managers for version tracking

Note: Veracode pipeline scanner uses LATEST (no versioned downloads)