### PR TITLE
Pinning audit to specific version

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -43,7 +43,7 @@ jobs:
       run: 'node -v'
     - name: Audit for vulnerabilities
       id: npm
-      run: npx audit-ci@^7 --config ./audit-ci.json -o json > npm-security-check-reports.json
+      run: npx audit-ci@7.1.0 --min-release-age=7 --config ./audit-ci.json -o json > npm-security-check-reports.json
       continue-on-error: true
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:

--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -43,7 +43,9 @@ jobs:
       run: 'node -v'
     - name: Audit for vulnerabilities
       id: npm
-      run: npx audit-ci@7.1.0 --min-release-age=7 --config ./audit-ci.json -o json > npm-security-check-reports.json
+      env:
+        NPM_CONFIG_MIN_RELEASE_AGE: '7'
+      run: npx audit-ci@7.1.0 --config ./audit-ci.json -o json > npm-security-check-reports.json
       continue-on-error: true
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:


### PR DESCRIPTION
npx defaults to any version in package-lock for the main command but if it's not installed then it will just pull the latest. 
There are a couple of services that don't have it installed so this is required for those.

npx does not respect package-lock for transitive dependencies of the command. To help mitigate supply chain attacks this sets a minimum release age. 

This will be respected if the build is running a later version of npmrc (11.10 - which comes with node 24)
Ideally services would have `min-release-age` set in their local npmrc files and inherit this but this captures places where it's not.

If the current npm version is prior to 11.10, it will just log a warning saying that the command isn't recognised.