### PR TITLE
CPR-1161 randomised startup time from scheduled downtime is now set i…

### DIFF
--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -51,16 +51,6 @@ on:
         required: false
         default: ${{ github.event.repository.name }}
         type: string
-      autogenerate_scheduled_downtime_cron:
-        description: |
-          Whether to autogenerate scheduled downtime cron values.
-          For services that have enabled "scheduledDowntime".
-          This will override the "startup" and "shutdown" cron values and set them during Helm install/upgrade.
-          Ensures startups and shutdowns are randomly spaced out to avoid cluster scheduling issues.
-          Startup times are between 6am-7am. Shutdown times are between 9pm-10pm.
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -121,7 +111,6 @@ jobs:
           helm_chart_name: ${{ inputs.helm_chart_name }}
           helm_allowlist_groups: ${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_YAML }}
           helm_allowlist_version: ${{ vars.HMPPS_IP_ALLOWLIST_GROUPS_VERSION }}
-          autogenerate_scheduled_downtime_cron: ${{inputs.autogenerate_scheduled_downtime_cron }}
 
       # Notification bit - always send prod releases to dps-releases - CVA3MKDTR
       - if: ${{ always() && ( inputs.environment == 'prod' || inputs.environment == 'production' ) }}


### PR DESCRIPTION
…n hmpps-helm-charts

[It does not look like this is in use](https://github.com/search?q=org%3Aministryofjustice+autogenerate_scheduled_downtime_cron&type=code)

Reverting part of https://github.com/ministryofjustice/hmpps-github-actions/pull/138/changes

To be merged after https://github.com/ministryofjustice/hmpps-helm-charts/pull/229

