### PR TITLE
Add workflow_call support to SharePoint backup workflow

### DIFF
--- a/.github/workflows/backup_repository.yml
+++ b/.github/workflows/backup_repository.yml
@@ -1,9 +1,31 @@
 name: Backup Repository to SharePoint
 
 on:
-  workflow_dispatch: # manual trigger
+  workflow_call:
+    inputs:
+      retention_count:
+        description: Number of backups to retain
+        required: false
+        type: number
+        default: 5
+    secrets:
+      SHAREPOINT_CLIENT_ID:
+        required: true
+      SHAREPOINT_CLIENT_SECRET:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      retention_count:
+        description: Number of backups to retain
+        required: false
+        type: number
+        default: 5
+
   schedule:
-    - cron: '35 1 * * *'
+    - cron: "35 1 * * *"
 
 permissions: {}
 
@@ -19,4 +41,4 @@ jobs:
       - name: Backup repository to SharePoint
         uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/sharepoint_repository_backup@e0e6abc2f67f2bbb81a74610d6c307ab468a1a77 # v1
         with:
-          retention_count: 5 # optional, defaults to 5
+          retention_count: ${{ inputs.retention_count || 5 }}


### PR DESCRIPTION
Currently, multiple repositories directly reference the shared action from hmpps-github-shared-action:

ministryofjustice/hmpps-github-shared-actions/.github/actions/sharepoint_repository_backup@<commit-sha> # v1
This approach causes Dependabot to raise PRs in every repository whenever a new release is published in hmpps-github-shared-actions, leading to frequent and repetitive updates.

Proposed Changes
Update hmpps-github-actions repository:

Modify backup_repository.yaml to support workflow_call.

Pin the shared action (sharepoint_repository_backup) to a specific commit SHA within this workflow.

Future dependabot PR change will be limited to only this repository. 

Tag/release it as v2 in hmpps-github-actions.

Update all consuming repositories:

Replace direct usage of the shared action with a call to the reusable workflow: 



hmpps-github-actions/.github/workflows/backup_repository.yaml@v2
Remove direct references to hmpps-github-shared-actions.