### PR TITLE
ESWE-1976: Cache Playwright browser binaries for integration tests

### DIFF
--- a/.github/workflows/node_build.yml
+++ b/.github/workflows/node_build.yml
@@ -40,6 +40,7 @@ jobs:
         path: |
           ./node_modules
           ~/.cache/Cypress
+          ~/.cache/ms-playwright
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
     - name: install dependencies
       if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -70,4 +71,5 @@ jobs:
         path: |
           ./node_modules
           ~/.cache/Cypress
+          ~/.cache/ms-playwright
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -64,6 +64,7 @@ jobs:
           path: |
             ./node_modules
             ~/.cache/Cypress
+            ~/.cache/ms-playwright
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: Init testing framework if necessary
         run: npm run int-test-init:ci --if-present

--- a/.github/workflows/node_integration_tests_redis.yml
+++ b/.github/workflows/node_integration_tests_redis.yml
@@ -42,6 +42,7 @@ jobs:
           path: |
             ./node_modules
             ~/.cache/Cypress
+            ~/.cache/ms-playwright
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/tool-installers/setup-wiremock@e0e6abc2f67f2bbb81a74610d6c307ab468a1a77 # v1
       - name: Prepare and run integration tests

--- a/.github/workflows/node_unit_tests.yml
+++ b/.github/workflows/node_unit_tests.yml
@@ -55,6 +55,7 @@ jobs:
           path: |
             ./node_modules
             ~/.cache/Cypress
+            ~/.cache/ms-playwright
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: download the artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
Ensure Playwright browser binaries are cached for use with integration tests
