### PR TITLE
Add optional parallel node integration tests

### DIFF
--- a/.github/scripts/run-node-integration-tests.mjs
+++ b/.github/scripts/run-node-integration-tests.mjs
@@ -1,0 +1,143 @@
+import { readdir } from 'node:fs/promises'
+import { spawn, spawnSync } from 'node:child_process'
+import { relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const MAX_SHARDS = 6
+const cypressPattern = /\.cy(?:\.|$)/
+const playwrightPattern = /\.spec(?:\.|$)/
+const testPatterns = [cypressPattern, playwrightPattern]
+const ignoredDirectories = new Set([
+  '.git',
+  '.hmpps-github-actions',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+])
+const childProcessOptions = { shell: false, stdio: 'inherit' }
+
+export function parseShardConfiguration(env) {
+  const shardCount = Number(env.SHARD_COUNT)
+  const shardIndex = Number(env.SHARD_INDEX)
+
+  if (!Number.isInteger(shardCount) || shardCount < 1 || shardCount > MAX_SHARDS) {
+    throw new Error(`shard_count must be an integer from 1 to ${MAX_SHARDS}; received "${env.SHARD_COUNT}"`)
+  }
+
+  return { shardCount, shardIndex }
+}
+
+export function selectShard(files, shardIndex, shardCount) {
+  return [...files].sort().filter((_, index) => index % shardCount === shardIndex - 1)
+}
+
+export function detectFramework(files) {
+  const hasCypressTests = files.some(file => cypressPattern.test(file))
+  const hasPlaywrightTests = files.some(file => playwrightPattern.test(file))
+
+  if (!hasCypressTests && !hasPlaywrightTests) {
+    throw new Error('No Cypress (.cy) or Playwright (.spec) test files were found')
+  }
+  if (hasCypressTests && hasPlaywrightTests) {
+    throw new Error('Both Cypress (.cy) and Playwright (.spec) test files were found; parallel runs must use one framework')
+  }
+
+  return hasCypressTests ? 'cypress' : 'playwright'
+}
+
+export function cypressTestArguments(npmScript, files) {
+  return ['run', npmScript, '--', '--spec', files.join(',')]
+}
+
+export function playwrightTestArguments(npmScript, shardIndex, shardCount) {
+  return ['run', npmScript, '--', `--shard=${shardIndex}/${shardCount}`]
+}
+
+async function discoverTestFiles(directory, root = directory) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && !ignoredDirectories.has(entry.name)) {
+      files.push(...await discoverTestFiles(resolve(directory, entry.name), root))
+    } else if (entry.isFile() && testPatterns.some(pattern => pattern.test(entry.name))) {
+      files.push(relative(root, resolve(directory, entry.name)).split(sep).join('/'))
+    }
+  }
+
+  return files
+}
+
+function runSync(command, args) {
+  const result = spawnSync(command, args, childProcessOptions)
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    const error = new Error(`${command} exited with status ${result.status ?? 1}`)
+    error.exitCode = result.status ?? 1
+    throw error
+  }
+}
+
+function start(command, args) {
+  const child = spawn(command, args, childProcessOptions)
+  child.on('error', error => {
+    console.error(`Failed to start ${command}:`, error)
+    process.exitCode = 1
+  })
+  return child
+}
+
+const sleep = milliseconds => new Promise(resolvePromise => setTimeout(resolvePromise, milliseconds))
+
+async function prepareTestArguments(npmScript, shardIndex, shardCount) {
+  if (shardCount === 1) return ['run', npmScript]
+
+  const files = await discoverTestFiles(process.cwd())
+  const framework = detectFramework(files)
+
+  if (framework === 'playwright') {
+    console.log(`Running Playwright shard ${shardIndex}/${shardCount}`)
+    return playwrightTestArguments(npmScript, shardIndex, shardCount)
+  }
+
+  const shardFiles = selectShard(files, shardIndex, shardCount)
+  console.log(`Shard ${shardIndex}/${shardCount}: selected ${shardFiles.length} of ${files.length} Cypress test files`)
+
+  if (shardFiles.length === 0) {
+    throw new Error(`Shard ${shardIndex}/${shardCount} has no test files; reduce shard_count`)
+  }
+
+  return cypressTestArguments(npmScript, shardFiles)
+}
+
+async function main() {
+  if (process.env.RUNNER_MODE === 'init') {
+    runSync('npm', ['run', 'int-test-init:ci', '--if-present'])
+    return
+  }
+
+  const npmScript = process.env.NPM_SCRIPT
+  if (!npmScript) throw new Error('npm_script must not be empty')
+
+  const { shardCount, shardIndex } = parseShardConfiguration(process.env)
+  const wiremockPort = process.env.WIREMOCK_PORT
+  const testArguments = await prepareTestArguments(npmScript, shardIndex, shardCount)
+  const wiremock = start('java', ['-jar', 'wiremock.jar', '--port', wiremockPort])
+  const feature = start('npm', ['run', 'start-feature'])
+
+  try {
+    await sleep(5000)
+    runSync('npm', testArguments)
+  } finally {
+    feature.kill()
+    wiremock.kill()
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    console.error(error.message)
+    process.exitCode = error.exitCode ?? 1
+  })
+}

--- a/.github/scripts/run-node-integration-tests.mjs
+++ b/.github/scripts/run-node-integration-tests.mjs
@@ -112,11 +112,6 @@ async function prepareTestArguments(npmScript, shardIndex, shardCount) {
 }
 
 async function main() {
-  if (process.env.RUNNER_MODE === 'init') {
-    runSync('npm', ['run', 'int-test-init:ci', '--if-present'])
-    return
-  }
-
   const npmScript = process.env.NPM_SCRIPT
   if (!npmScript) throw new Error('npm_script must not be empty')
 

--- a/.github/scripts/run-node-integration-tests.test.mjs
+++ b/.github/scripts/run-node-integration-tests.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  cypressTestArguments,
+  detectFramework,
+  parseShardConfiguration,
+  playwrightTestArguments,
+  selectShard,
+} from './run-node-integration-tests.mjs'
+
+test('rejects shard counts above the supported maximum', () => {
+  assert.throws(() => parseShardConfiguration({ SHARD_COUNT: '7', SHARD_INDEX: '1' }), /shard_count must be an integer from 1 to 6/)
+})
+
+test('selects a deterministic shard after sorting files', () => {
+  assert.deepEqual(selectShard(['c.spec.ts', 'a.spec.ts', 'b.spec.ts'], 2, 2), ['b.spec.ts'])
+})
+
+test('detects Cypress and Playwright files', () => {
+  assert.equal(detectFramework(['integration/example.cy.ts']), 'cypress')
+  assert.equal(detectFramework(['integration/example.spec.ts']), 'playwright')
+})
+
+test('rejects mixed test frameworks', () => {
+  assert.throws(() => detectFramework(['a.cy.ts', 'b.spec.ts']), /Both Cypress/)
+})
+
+test('builds Cypress npm arguments', () => {
+  assert.deepEqual(
+    cypressTestArguments('int-test', ['a.cy.ts', 'b.cy.ts']),
+    ['run', 'int-test', '--', '--spec', 'a.cy.ts,b.cy.ts'],
+  )
+})
+
+test('builds Playwright npm arguments using native sharding', () => {
+  assert.deepEqual(
+    playwrightTestArguments('int-test', 2, 3),
+    ['run', 'int-test', '--', '--shard=2/3'],
+  )
+})

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -14,7 +14,7 @@ on:
         type: number
         default: 1
       test_results_artifact_name:
-        description: 'Name of uploaded test results artifact; must be unique across pipeline'
+        description: 'Name of uploaded test results artifact; must be unique across pipeline (eg. in matrix strategies for parallelised tests)'
         required: false
         type: string
         default: 'npm_integration_test_artifacts'

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -119,7 +119,7 @@ jobs:
             ctrf/
       - name: publish test report
         if: ${{ !cancelled() && github.event.repository.visibility == 'public' }}
-        uses: dorny/test-reporter@1cc81a5edf733718d4850df304aaa21c05cd7280 # v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           artifact: ${{ inputs.shard_count == 1 && inputs.test_results_artifact_name || format('{0}-shard-{1}', inputs.test_results_artifact_name, matrix.shard) }}
           name: ${{ inputs.shard_count == 1 && 'Test Report' || format('Test Report – shard {0}/{1}', matrix.shard, inputs.shard_count) }}
@@ -131,7 +131,7 @@ jobs:
           list-tests: 'failed'
       - name: fail the action if the tests failed
         if: ${{ steps.integration-tests.outcome == 'failure' }}
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.setFailed('Integration tests failed')

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -94,9 +94,7 @@ jobs:
             ~/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: Init testing framework if necessary
-        env:
-          RUNNER_MODE: init
-        run: node .hmpps-github-actions/.github/scripts/run-node-integration-tests.mjs
+        run: npm run int-test-init:ci --if-present
       - uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/tool-installers/setup-wiremock@97eeedc606b4ce163133d203259a71698c9ad34b # v1.0.16
       - name: Prepare and run integration tests
         id: integration-tests

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -8,8 +8,13 @@ on:
         required: false
         type: string
         default: 'int-test'
+      shard_count:
+        description: 'Number of parallel Cypress or Playwright test shards to run (1-6)'
+        required: false
+        type: number
+        default: 1
       test_results_artifact_name:
-        description: 'Name of uploaded test results artifact; must be unqiue across pipeline (eg. in matrix strategies for parallelised tests)'
+        description: 'Name of uploaded test results artifact; must be unique across pipeline'
         required: false
         type: string
         default: 'npm_integration_test_artifacts'
@@ -33,8 +38,22 @@ permissions:
 
 jobs:
   integration_test:
-    name: ${{ inputs.npm_script == 'int-test' && 'Run the integration tests' || format('Run the integration tests – {0}', inputs.npm_script) }}
+    name: Run the integration tests${{ inputs.npm_script == 'int-test' && '' || format(' – {0}', inputs.npm_script) }}${{ inputs.shard_count == 1 && '' || format(' – shard {0}/{1}', matrix.shard, inputs.shard_count) }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: >-
+          ${{
+            fromJSON(
+              inputs.shard_count == 2 && '[1,2]' ||
+              inputs.shard_count == 3 && '[1,2,3]' ||
+              inputs.shard_count == 4 && '[1,2,3,4]' ||
+              inputs.shard_count == 5 && '[1,2,3,4,5]' ||
+              inputs.shard_count == 6 && '[1,2,3,4,5,6]' ||
+              '[1]'
+            )
+          }}
     services:
       redis:
         image: ${{ inputs.redis_tag && format('redis:{0}', inputs.redis_tag) || '' }}
@@ -47,6 +66,15 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Check out the shared workflow runner
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .hmpps-github-actions
+          persist-credentials: false
       - name: Use Node.js ${{ inputs.node_version_file }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -66,21 +94,23 @@ jobs:
             ~/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: Init testing framework if necessary
-        run: npm run int-test-init:ci --if-present
+        env:
+          RUNNER_MODE: init
+        run: node .hmpps-github-actions/.github/scripts/run-node-integration-tests.mjs
       - uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/tool-installers/setup-wiremock@97eeedc606b4ce163133d203259a71698c9ad34b # v1.0.16
       - name: Prepare and run integration tests
         id: integration-tests
-        shell: bash
-        run: |
-          nohup java -jar wiremock.jar --port ${{ inputs.wiremock_port }} &
-          nohup npm run start-feature &
-          sleep 5
-          npm run ${{ inputs.npm_script }}
+        env:
+          NPM_SCRIPT: ${{ inputs.npm_script }}
+          SHARD_COUNT: ${{ inputs.shard_count }}
+          SHARD_INDEX: ${{ matrix.shard }}
+          WIREMOCK_PORT: ${{ inputs.wiremock_port }}
+        run: node .hmpps-github-actions/.github/scripts/run-node-integration-tests.mjs
       - name: upload results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ inputs.test_results_artifact_name }}
+          name: ${{ inputs.shard_count == 1 && inputs.test_results_artifact_name || format('{0}-shard-{1}', inputs.test_results_artifact_name, matrix.shard) }}
           path: |
             integration_tests/videos/
             integration_tests/screenshots/
@@ -89,10 +119,10 @@ jobs:
             ctrf/
       - name: publish test report
         if: ${{ !cancelled() && github.event.repository.visibility == 'public' }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: dorny/test-reporter@1cc81a5edf733718d4850df304aaa21c05cd7280 # v3
         with:
-          artifact: ${{ inputs.test_results_artifact_name }}
-          name: Test Report
+          artifact: ${{ inputs.shard_count == 1 && inputs.test_results_artifact_name || format('{0}-shard-{1}', inputs.test_results_artifact_name, matrix.shard) }}
+          name: ${{ inputs.shard_count == 1 && 'Test Report' || format('Test Report – shard {0}/{1}', matrix.shard, inputs.shard_count) }}
           path: 'test_results/**/*.xml'
           reporter: java-junit
           fail-on-empty: false
@@ -101,7 +131,7 @@ jobs:
           list-tests: 'failed'
       - name: fail the action if the tests failed
         if: ${{ steps.integration-tests.outcome == 'failure' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             core.setFailed('Integration tests failed')


### PR DESCRIPTION
Add optional parallel execution to the shared Node integration-test workflow, replacing repeated service-level implementations with an MOJ-owned runner. Existing callers continue to run tests as a single job by default.