### PR TITLE
add artifact path options

### DIFF
--- a/.github/workflows/node_build.yml
+++ b/.github/workflows/node_build.yml
@@ -13,6 +13,14 @@ on:
         required: false
         type: string
         default: "npm ci --no-audit"
+      artifact_path:
+        description: "The paths to the build artifacts"
+        required: false
+        type: string
+        default: |
+          build/
+          dist/
+          assets/stylesheets/
 
 permissions:
   contents: read
@@ -59,10 +67,7 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with: 
         name: npm_build_artifacts
-        path: |
-          build/
-          dist/
-          assets/stylesheets/
+        path: "${{ inputs.artifact_path }}"
     - name: save cache
       id: save-cache
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/node_unit_tests.yml
+++ b/.github/workflows/node_unit_tests.yml
@@ -13,6 +13,15 @@ on:
         required: false
         type: string
         default: 'npm_unit_test_artifacts'
+      test_results_artifact_path:
+        description: "The paths to the test results artifacts"
+        required: false
+        type: string
+        default: "test_results"
+      download_path:
+        description: 'Destination path for download-artifact action. If not provided, input is not used'
+        required: false
+        type: string
       node_version_file:
         description: "Passed to setup-node action to specify where to source the version of node from"
         required: false
@@ -58,7 +67,14 @@ jobs:
             ./node_modules
             ~/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
-      - name: download the artifacts
+      - name: download the artifacts to a custom path if provided
+        if: ${{ inputs.download_path != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: npm_build_artifacts
+          path: ${{ inputs.download_path }}
+      - name: download the artifacts to default path if custom path not provided
+        if: ${{ inputs.download_path == '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: npm_build_artifacts
@@ -74,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ inputs.test_results_artifact_name }}
-          path: test_results
+          path: ${{ inputs.test_results_artifact_path }}
       - name: publish test report
         if: ${{ !cancelled() && github.event.repository.visibility == 'public' }}
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,20 @@ Build multi_platform images in parallel, native runners by Thomas-Geraghty (PR 1
 
 ## v2.10.0
 
-Migrate to use the hmpps-github-shared-actions repository for shared actions
+Migrate to use the hmpps-github-shared-actions repository for shared actions(PR 212)
+
+## v2.11.0
+
+Implementation of separate tool installers, including checksum validation (PR 219)
+
+## v2.13.0
+
+Adding Gradle encryption caching configuration (PR 227)
+
+## v2.14.0
+
+Implementation of optional SBOM creation to Docker workflows (including optional attestation) (PR 228)
+
+## v2.15.0
+
+Adding options for custom node artifacts and path (PR 285)


### PR DESCRIPTION
Raised by Jasper Jackson - this enables custom artifacts to be uploaded, rather than just the standard ones.

Defaults remain the standard set, so it's backwards compatible with existing workflows.
