### PR TITLE
Add image version option

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -52,6 +52,11 @@ on:
         description: Name of the image
         required: false
         type: string
+      image_version:
+        description: Version tag of the image. Generated when not provided
+        required: false
+        type: string
+        default: ''
       file:
         description: "Path to the Dockerfile"
         required: false
@@ -92,11 +97,14 @@ jobs:
     name: Create app version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.app_version.outputs.version }}
+      version: ${{ steps.image_version.outputs.version }}
     steps:
       - id: app_version
         name: Create application version
-        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@122496e475fb4a2a5a808c9677f10de010737984 # v1.0.20
+        if: inputs.image_version == ''
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@c89a206b6b32888d13f6aec01af0f7694df6b42f # v1.0.19
+      - id: image_version
+        run: echo "version=${{ inputs.image_version || steps.app_version.outputs.version }}" >> $GITHUB_OUTPUT
 
   docker_build:
     name: Build linux/amd64 (single)


### PR DESCRIPTION
- Add image-version parameter
-- Allows a version to be passed instead of regenerated.
--- Generally the application version has already been generated for the code build
--- Also allows a modified version to be passed. Such as a version with an additional suffix.
