### PR TITLE
Timezone and debugger options

### DIFF
--- a/.github/workflows/gradle_verify.yml
+++ b/.github/workflows/gradle_verify.yml
@@ -73,6 +73,12 @@ on:
         type: boolean
         default: false
         required: false
+      debug-gradle-runner:
+        description: Whether to stop the job to allow access to the runner of the gradle step
+        type: boolean
+        default: false
+        required: false
+
 permissions:
   contents: read
 jobs:
@@ -124,6 +130,9 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+      - name: Setup Debug Session
+        if: inputs.debug-gradle-runner
+        uses: csexton/debugger-action@0de54ee5b983a6f5a84a5a0c1e708422059837e0 # master
       - name: Run checks with gradle
         shell: bash
         env:

--- a/.github/workflows/node_integration_tests.yml
+++ b/.github/workflows/node_integration_tests.yml
@@ -27,6 +27,16 @@ on:
         required: false
         type: number
         default: 9091
+      runner_timezone:
+        description: 'Set the runners timezone'
+        required: false
+        type: string
+        default: ''
+      debug-node-runner:
+        description: 'Whether to pause the job to allow runner attachment'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -78,12 +88,16 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '!**/node_modules/**') }}
       - name: Init testing framework if necessary
         run: npm run int-test-init:ci --if-present
+      - name: Setup Debug Session
+        if: inputs.debug-node-runner
+        uses: csexton/debugger-action@0de54ee5b983a6f5a84a5a0c1e708422059837e0 # master
       - name: Prepare and run integration tests
         id: integration-tests
         shell: bash
         env:
           NPM_SCRIPT: ${{ inputs.npm_script }}
         run: |
+          export TZ="${{ inputs.runner_timezone }}"
           nohup npm run start-feature &
           sleep 5
           npm run "${NPM_SCRIPT}"


### PR DESCRIPTION
- Add timezone parameter.
-- Our integration tests perform time assertions based on the localised time.
- Add optional action runner session debugger
-- Useful for debugging integration test problems, such as the timezone problem.

Without the TZ addition, our project is forced to use a copy of the shared _node_integration_tests.yml_
